### PR TITLE
Use BuildKit and caching in example pipeline

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eux
+apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+apt-cache policy docker-ce
+apt-get upgrade docker-ce
+cat /etc/docker/daemon.json > /tmp/daemon.json
+sed 's/{/{"experimental": true,/' < /tmp/daemon.json > /etc/docker/daemon.json
+cat /etc/docker/daemon.json
+sudo systemctl restart docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: c
-script: docker build .
+script:
+  - sudo ./.travis-docker.sh
+  - docker build --progress=plain .
+dist: bionic
 sudo: required
 services:
   - docker
 env:
-  - OPAMERRLOGLEN=0
+  - DOCKER_BUILDKIT=1 OPAMERRLOGLEN=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+#syntax=docker/dockerfile-upstream
+# The above line allows the --mount option below, which makes incremental builds faster.
+# If you want to use older versions of Docker, you can just remove the --mount argument.
 FROM ocaml/opam2:4.08
 RUN sudo apt-get update && sudo apt-get install graphviz m4 pkg-config libsqlite3-dev -y --no-install-recommends
 RUN git pull origin master && git reset --hard f372039db86a970ef3e662adbfe0d4f5cd980701 && opam update
@@ -5,4 +8,6 @@ ADD --chown=opam *.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only -t .
 ADD --chown=opam . .
-RUN opam config exec -- make -C .
+RUN --mount=type=cache,id=dune,target=/src/_build,sharing=locked,uid=1000,gid=1000 \
+    opam config exec -- dune build --display=short @all && \
+    sudo install _build/default/examples/docker_build_local.exe /usr/local/bin/docker_build_local

--- a/examples/docker_build_local.ml
+++ b/examples/docker_build_local.ml
@@ -5,11 +5,13 @@ let pull = false    (* Whether to check for updates using "docker build --pull" 
 
 let () = Logging.init ()
 
+let () = Unix.putenv "DOCKER_BUILDKIT" "1"
+
 (* Run "docker build" on the latest commit in Git repository [repo]. *)
 let pipeline ~repo () =
   let src = Git.Local.head_commit repo in
   let image = Docker.build ~pull (`Git src) in
-  Docker.run image ~args:["dune"; "exec"; "--"; "examples/docker_build_local.exe"; "--help"]
+  Docker.run image ~args:["docker_build_local"; "--help"]
 
 let main config mode repo =
   let repo = Git.Local.v (Fpath.v repo) in


### PR DESCRIPTION
This allows for fast incremental builds. It relies on dune doing incremental builds correctly.