### PR TITLE
Make Output.pp more polymorphic

### DIFF
--- a/lib_term/output.mli
+++ b/lib_term/output.mli
@@ -4,4 +4,4 @@ type active = [`Ready | `Running]
 type 'a t = ('a, [`Active of active | `Msg of string]) result
   [@@deriving eq]
 
-val pp : 'a Fmt.t -> 'a t Fmt.t
+val pp : 'a Fmt.t -> ('a, [< `Active of active | `Msg of string]) result Fmt.t


### PR DESCRIPTION
This allows it to be used with `catch`, not just `state`.