### PR TITLE
Create manifests using a fresh docker config dir

### DIFF
--- a/plugins/docker/cmd.ml
+++ b/plugins/docker/cmd.ml
@@ -1,12 +1,16 @@
-let host_args = function
+let context_args = function
   | None -> []
   | Some context -> ["--context"; context]
 
-let docker ~docker_context args =
-  "", Array.of_list ("docker" :: host_args docker_context @ args)
+let config_args = function
+  | None -> []
+  | Some config -> ["--config"; Fpath.to_string config]
 
-let login ~docker_context ~user =
-  docker ~docker_context ["login"; "--password-stdin"; "--username"; user]
+let docker ?config ~docker_context args =
+  "", Array.of_list ("docker" :: config_args config @ context_args docker_context @ args)
+
+let login ?config ~docker_context user =
+  docker ?config ~docker_context ["login"; "--password-stdin"; "--username"; user]
 
 let pp f (prog, args) =
   if prog <> "" then Fmt.pf f "[%S] " prog;

--- a/plugins/docker/push.ml
+++ b/plugins/docker/push.ml
@@ -41,7 +41,7 @@ let publish ~switch auth job key value =
     begin match auth with
       | None -> Lwt.return (Ok ())
       | Some (user, password) ->
-        let cmd = Cmd.login ~docker_context ~user in
+        let cmd = Cmd.login ~docker_context user in
         Current.Process.exec ~switch ~job ~stdin:password cmd
     end >>!= fun () ->
     let cmd = Cmd.docker ~docker_context ["push"; tag] in

--- a/plugins/docker/push_manifest.ml
+++ b/plugins/docker/push_manifest.ml
@@ -27,26 +27,30 @@ end
 
 module Outcome = Current.Unit
 
-let create_cmd ~tag {Value.manifests} =
-  let args = ["docker"; "manifest"; "create"; tag] @ manifests in
-  ("", Array.of_list args)
+let create_cmd ~config ~tag {Value.manifests} =
+  Cmd.docker ~config ~docker_context:None (["manifest"; "create"; tag] @ manifests)
 
-let push_cmd tag =
-  let args = ["docker"; "manifest"; "push"; tag] in
-  ("", Array.of_list args)
+let push_cmd ~config tag =
+  Cmd.docker ~config ~docker_context:None ["manifest"; "push"; tag]
+
+let or_fail = function
+  | Ok x -> x
+  | Error (`Msg x) -> failwith x
 
 let publish ~switch auth job tag value =
-  Current.Process.exec ~switch ~job (create_cmd ~tag value) >>= function
+  Current.Process.with_tmpdir ~prefix:"push-manifest" @@ fun config ->
+  Bos.OS.File.write Fpath.(config / "config.json") {|{"experimental": "enabled"}|} |> or_fail;
+  Current.Process.exec ~switch ~job (create_cmd ~config ~tag value) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->
     Lwt_mutex.with_lock push_mutex @@ fun () ->
     begin match auth with
       | None -> Lwt.return (Ok ())
       | Some (user, password) ->
-        let cmd = Cmd.login ~docker_context:None ~user in
+        let cmd = Cmd.login ~config ~docker_context:None user in
         Current.Process.exec ~switch ~job ~stdin:password cmd
     end >>!= fun () ->
-    Current.Process.exec ~switch ~job (push_cmd tag)
+    Current.Process.exec ~switch ~job (push_cmd ~config tag)
 
 let pp f (tag, value) =
   Fmt.pf f "push %s = %s" tag (Value.digest value)


### PR DESCRIPTION
There's no way to delete manifests, so otherwise if a push fails then there is no way to recover.