### PR TITLE
Require cohttp-lwt-unix >= 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam2:4.08
 RUN sudo apt-get update && sudo apt-get install graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN git pull origin master && git reset --hard f372039db86a970ef3e662adbfe0d4f5cd980701 && opam update
+RUN git pull origin master && git reset --hard b70af589a3a2e7aa2202b499b8c669fa4e51bf42 && opam update
 ADD --chown=opam *.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only -t .

--- a/current_web.opam
+++ b/current_web.opam
@@ -16,7 +16,7 @@ depends: [
   "bos"
   "lwt"
   "cmdliner"
-  "cohttp-lwt-unix"
+  "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
   "dune" {build}
 ]


### PR DESCRIPTION
Should fix crashes when client closes their browser window during a transfer.