### PR TITLE
Add Prometheus metric reporting

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -18,6 +18,7 @@ depends: [
   "cmdliner"
   "sqlite3"
   "duration"
+  "prometheus"
   "dune" {build}
   "alcotest-lwt" {with-test}
 ]

--- a/current_web.opam
+++ b/current_web.opam
@@ -16,6 +16,7 @@ depends: [
   "bos"
   "lwt"
   "cmdliner"
+  "prometheus-app"
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
   "dune" {build}

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
   (public_name current)
-  (libraries current_term lwt cmdliner sqlite3 lwt.unix)
+  (libraries current_term lwt cmdliner sqlite3 lwt.unix prometheus)
   (preprocess (per_module
                 ((pps ppx_deriving.std) level)
               )))

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -131,6 +131,11 @@ let handle_request ~engine _conn request body =
     | `GET, ["query"] ->
       let body = Query.render uri in
       Server.respond_string ~status:`OK ~body ()
+    | `GET, ["metrics"] ->
+      let data = Prometheus.CollectorRegistry.(collect default) in
+      let body = Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data in
+      let headers = Cohttp.Header.init_with "Content-Type" "text/plain; version=0.0.4" in
+      Server.respond_string ~status:`OK ~headers ~body ()
     | _ ->
       Server.respond_not_found ()
 

--- a/lib_web/dune
+++ b/lib_web/dune
@@ -1,3 +1,3 @@
 (library
   (public_name current_web)
-  (libraries current current.cache lwt.unix cohttp-lwt-unix tyxml))
+  (libraries current current.cache lwt.unix cohttp-lwt-unix tyxml prometheus-app))


### PR DESCRIPTION
At the moment, this just reports the number of evaluations (plus the standard metrics such as heap size and CPU time).