### PR TITLE
Add Github.Commit module

### DIFF
--- a/examples/github.ml
+++ b/examples/github.ml
@@ -28,7 +28,7 @@ let github_status_of_state = function
 
 let pipeline ~github ~repo () =
   let head = Github.Api.head_commit github repo in
-  let src = Git.fetch head in
+  let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   let dockerfile =
     let+ base = Docker.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08" in
     dockerfile ~base
@@ -36,7 +36,7 @@ let pipeline ~github ~repo () =
   Docker.build ~pull:false ~dockerfile (`Git src)
   |> Current.state
   |> Current.map github_status_of_state
-  |> Github.Api.set_commit_status github head "ocurrent"
+  |> Github.Api.Commit.set_status head "ocurrent"
 
 let webhooks = [
   "github", Github.input_webhook

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -1,12 +1,18 @@
 (* Public API; see Current_git.mli for details of these: *)
 
-type t
 type status = [`Error | `Failure | `Pending | `Success ]
+
+module Commit : sig
+  type t
+  val id : t -> Current_git.Commit_id.t
+  val set_status : t Current.t -> string -> status Current.t -> unit Current.t
+end
+
+type t
 val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
-val head_commit : t -> Repo_id.t -> Current_git.Commit_id.t Current.t
-val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Current_git.Commit_id.t Current.t
-val set_commit_status : t -> Current_git.Commit_id.t Current.t -> string -> status Current.t -> unit Current.t
+val head_commit : t -> Repo_id.t -> Commit.t Current.t
+val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t Current.t
 val cmdliner : t Cmdliner.Term.t
 
 (* Private API *)

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -23,20 +23,27 @@ module Api : sig
   type status = [`Error | `Failure | `Pending | `Success ]
   (** GitHub commit context status type. *)
 
+  module Commit : sig
+    type t
+
+    val id : t -> Current_git.Commit_id.t
+    (** The commit ID, which can be used to fetch it. *)
+
+    val set_status : t Current.t -> string -> status Current.t -> unit Current.t
+    (** [set_status commit context status] sets the status of [commit]/[context] to [status]. *)
+  end
+
   val of_oauth : string -> t
   (** [of_oauth token] is a configuration that authenticates to GitHub using [token]. *)
 
   val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
   (** [exec_graphql t query] executes [query] on GitHub. *)
 
-  val head_commit : t -> Repo_id.t -> Current_git.Commit_id.t Current.t
+  val head_commit : t -> Repo_id.t -> Commit.t Current.t
   (** [head_commit t repo] evaluates to the commit at the head of the default branch in [repo]. *)
 
-  val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Current_git.Commit_id.t Current.t
+  val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t Current.t
   (** Like [head_commit], but the inputs are both currents. *)
-
-  val set_commit_status : t -> Current_git.Commit_id.t Current.t -> string -> status Current.t -> unit Current.t
-  (** [set_commit_status t commit context status] sets the status of [commit]/[context] to [status]. *)
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub configuration. *)


### PR DESCRIPTION
This bundles the API auth with the commit, which makes it easier to set the commit status.

Used this to update the GitHub app example to set commit statuses.