### PR TITLE
Allow monitoring branches and PRs

### DIFF
--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -20,8 +20,9 @@ module Fetch = struct
   let id = "git-fetch"
 
   let build ~switch ~set_running No_context job key =
-    set_running ();
     let { Commit_id.repo = remote_repo; gref; hash = _ } = key in
+    Lwt_mutex.with_lock (Clone.repo_lock remote_repo) @@ fun () ->
+    set_running ();
     let local_repo = Cmd.local_copy remote_repo in
     (* Ensure we have a local clone of the repository. *)
     begin

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -5,6 +5,7 @@ type status = [`Error | `Failure | `Pending | `Success ]
 module Commit : sig
   type t
   val id : t -> Current_git.Commit_id.t
+  val pp : t Fmt.t
   val set_status : t Current.t -> string -> status Current.t -> unit Current.t
 end
 
@@ -13,6 +14,8 @@ val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
 val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t Current.t
+val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
+val ci_refs_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t
 
 (* Private API *)

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -31,6 +31,8 @@ module Api : sig
 
     val set_status : t Current.t -> string -> status Current.t -> unit Current.t
     (** [set_status commit context status] sets the status of [commit]/[context] to [status]. *)
+
+    val pp : t Fmt.t
   end
 
   val of_oauth : string -> t
@@ -44,6 +46,12 @@ module Api : sig
 
   val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t Current.t
   (** Like [head_commit], but the inputs are both currents. *)
+
+  val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
+  (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo]. *)
+
+  val ci_refs_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t list Current.t
+  (** Like [ci_refs], but the inputs are both currents. *)
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub configuration. *)


### PR DESCRIPTION
Update GitHub app example to do this.

Also, add git-clone lock, so we don't try to clone the same repository in parallel.

Note: this doesn't use cursors yet, so it only monitors the first 100 refs and open PRs.