### PR TITLE
Various improvements to jobs

### DIFF
--- a/examples/docker_build_local.ml
+++ b/examples/docker_build_local.ml
@@ -3,12 +3,14 @@ module Docker = Current_docker.Default
 
 let pull = false    (* Whether to check for updates using "docker build --pull" *)
 
+let timeout = Duration.of_min 50    (* Max build time *)
+
 let () = Logging.init ()
 
 (* Run "docker build" on the latest commit in Git repository [repo]. *)
 let pipeline ~repo () =
   let src = Git.Local.head_commit repo in
-  let image = Docker.build ~pull (`Git src) in
+  let image = Docker.build ~pull ~timeout (`Git src) in
   Docker.run image ~args:["dune"; "exec"; "--"; "examples/docker_build_local.exe"; "--help"]
 
 let main config mode repo =

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -1,0 +1,39 @@
+open Lwt.Infix
+
+type t = {
+  mutable confirm : Level.t option;
+  level_cond : unit Lwt_condition.t;
+}
+
+let v ?confirm () =
+  let level_cond = Lwt_condition.create () in
+  { confirm; level_cond }
+
+let default = v ()
+
+let set_confirm t level =
+  t.confirm <- level;
+  Lwt_condition.broadcast t.level_cond ()
+
+let get_confirm t = t.confirm
+
+let rec confirmed l t =
+  match t.confirm with
+  | Some threshold when Level.compare l threshold >= 0 ->
+    Lwt_condition.wait t.level_cond >>= fun () ->
+    confirmed l t
+  | _ ->
+    Lwt.return_unit
+
+open Cmdliner
+
+let cmdliner_confirm =
+  let levels = List.map (fun l -> Level.to_string l, Some l) Level.values in
+  let conv = Arg.enum @@ ("none", None) :: levels in
+  Arg.opt conv None @@
+  Arg.info ~doc:"Confirm before starting operations at or above this level."
+    ["confirm"]
+
+let cmdliner =
+  let make confirm = v ?confirm () in
+  Term.(const make $ Arg.value cmdliner_confirm)

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -235,7 +235,14 @@ module Job : sig
   val create : switch:Switch.t -> label:string -> unit -> t
   (** [create ~switch ~label ()] is a new job.
       @param switch Turning this off will cancel the job.
-      @param label A label to use in the job's filename (for debugging).*)
+      @param label A label to use in the job's filename (for debugging). *)
+
+  val set_running : t -> unit
+  (** [set_running t] marks [t] as running. This can only be called once per job. *)
+
+  val start_time : t -> float Lwt.t
+  (** [start_time t] is the time when [set_running] was called, or an
+      unresolved promise for it if [set_running] hasn't been called yet. *)
 
   val write : t -> string -> unit
   (** [write t data] appends [data] to the log. *)
@@ -252,6 +259,13 @@ module Job : sig
   val fd : t -> Unix.file_descr
 
   val pp_id : job_id Fmt.t
+
+  (**/**)
+
+  (* For unit tests we need our own test clock: *)
+
+  val timestamp : (unit -> float) ref
+  val sleep : (float -> unit Lwt.t) ref
 end
 
 module Process : sig

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -46,9 +46,7 @@ module Step : sig
   (** [id t] is a unique value for this evaluation step.
       This can be useful to detect if e.g. the same output has been set to two different values in one step. *)
 
-  val confirmed : Level.t -> t -> unit Lwt.t
-  (** [confirmed l t] is a promise that resolves once we are ready to run
-      an action at level [l] or higher. *)
+  val config : t -> Config.t
 end
 
 module Input : sig
@@ -236,13 +234,14 @@ end
 module Job : sig
   type t
 
-  val create : switch:Switch.t -> label:string -> unit -> t
-  (** [create ~switch ~label ()] is a new job.
+  val create : switch:Switch.t -> label:string -> config:Config.t -> unit -> t
+  (** [create ~switch ~label ~config ()] is a new job.
       @param switch Turning this off will cancel the job.
       @param label A label to use in the job's filename (for debugging). *)
 
-  val start : ?timeout:Duration.t -> t -> unit Lwt.t
-  (** [start t] marks [t] as running. This can only be called once per job.
+  val start : ?timeout:Duration.t -> level:Level.t -> t -> unit Lwt.t
+  (** [start t ~level] marks [t] as running. This can only be called once per job.
+      If confirmation has been configured for [level], then this will wait for confirmation first.
       @param timeout If given, the job will be cancelled automatically after this period of time. *)
 
   val start_time : t -> float Lwt.t

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -241,13 +241,13 @@ module Job : sig
       @param switch Turning this off will cancel the job.
       @param label A label to use in the job's filename (for debugging). *)
 
-  val set_running : ?timeout:Duration.t -> t -> unit
-  (** [set_running t] marks [t] as running. This can only be called once per job.
+  val start : ?timeout:Duration.t -> t -> unit Lwt.t
+  (** [start t] marks [t] as running. This can only be called once per job.
       @param timeout If given, the job will be cancelled automatically after this period of time. *)
 
   val start_time : t -> float Lwt.t
-  (** [start_time t] is the time when [set_running] was called, or an
-      unresolved promise for it if [set_running] hasn't been called yet. *)
+  (** [start_time t] is the time when [start] was called, or an
+      unresolved promise for it if [start] hasn't been called yet. *)
 
   val write : t -> string -> unit
   (** [write t data] appends [data] to the log. *)

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -225,6 +225,10 @@ module Switch : sig
   val is_on : t -> bool
   (** [is_on t] is [true] if [turn_off t] hasn't yet been called. *)
 
+  val add_timeout : t -> Duration.t -> unit
+  (** [add_timeout t duration] adds a timeout that will wait for [duration] and
+      then turn off the switch. *)
+
   val pp : t Fmt.t
   (** Prints the state of the switch (for debugging). *)
 end
@@ -237,8 +241,9 @@ module Job : sig
       @param switch Turning this off will cancel the job.
       @param label A label to use in the job's filename (for debugging). *)
 
-  val set_running : t -> unit
-  (** [set_running t] marks [t] as running. This can only be called once per job. *)
+  val set_running : ?timeout:Duration.t -> t -> unit
+  (** [set_running t] marks [t] as running. This can only be called once per job.
+      @param timeout If given, the job will be cancelled automatically after this period of time. *)
 
   val start_time : t -> float Lwt.t
   (** [start_time t] is the time when [set_running] was called, or an

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
   (public_name current)
-  (libraries current_term lwt cmdliner sqlite3 lwt.unix prometheus)
+  (libraries current_term lwt cmdliner sqlite3 lwt.unix prometheus duration)
   (preprocess (per_module
                 ((pps ppx_deriving.std) level)
               )))

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -93,11 +93,12 @@ let pp_id = Fmt.string
 
 let is_running t = Lwt.state t.start_time <> Lwt.Sleep
 
-let set_running t =
+let set_running ?timeout t =
   if is_running t then (
     Log.warn (fun f -> f "set_running called, but job %a is already running!" Fpath.pp t.log);
     Fmt.failwith "Job.set_running called twice!"
   );
-  Lwt.wakeup t.set_start_time (!timestamp ())
+  Lwt.wakeup t.set_start_time (!timestamp ());
+  Option.iter (Switch.add_timeout t.switch) timeout
 
 let start_time t = t.start_time

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -93,12 +93,13 @@ let pp_id = Fmt.string
 
 let is_running t = Lwt.state t.start_time <> Lwt.Sleep
 
-let set_running ?timeout t =
+let start ?timeout t =
   if is_running t then (
-    Log.warn (fun f -> f "set_running called, but job %a is already running!" Fpath.pp t.log);
-    Fmt.failwith "Job.set_running called twice!"
+    Log.warn (fun f -> f "start called, but job %a is already running!" Fpath.pp t.log);
+    Fmt.failwith "Job.start called twice!"
   );
   Lwt.wakeup t.set_start_time (!timestamp ());
-  Option.iter (Switch.add_timeout t.switch) timeout
+  Option.iter (Switch.add_timeout t.switch) timeout;
+  Lwt.return_unit
 
 let start_time t = t.start_time

--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -99,8 +99,8 @@ module Make(B : S.BUILDER) = struct
       match Lwt.state (Job.start_time job) with
       | Lwt.Return time -> Some (Unix.gmtime time)
       | Lwt.Sleep when Stdlib.Result.is_ok value ->
-        Log.warn (fun f -> f "Build %a succeeded, but never called set_running!" B.pp build.key);
-        Fmt.failwith "Job.set_running not called!"
+        Log.warn (fun f -> f "Build %a succeeded, but never called start!" B.pp build.key);
+        Fmt.failwith "Job.start not called!"
       | _ -> None
     in
     let end_time = !Job.timestamp () in
@@ -414,7 +414,7 @@ module Output(Op : S.PUBLISHER) = struct
                    confirm ~job (Current.Step.confirmed level step, level) >>= fun () ->
                    Op.publish ~switch ctx job output.key (Value.value op.value) >|= fun r ->
                    if Stdlib.Result.is_ok r && Lwt.state (Job.start_time job) = Lwt.Sleep then
-                     Fmt.failwith "Job.set_running not called!";
+                     Fmt.failwith "Job.start not called!";
                    r
                 )
                 (fun ex -> Lwt.return (Error (`Msg (Printexc.to_string ex))))

--- a/lib_cache/current_cache.mli
+++ b/lib_cache/current_cache.mli
@@ -47,10 +47,3 @@ module Db : sig
         @param ok : if present, restrict results to passing (ok=true) or failing (ok=false) results. *)
   end
 end
-
-(**/**)
-
-(* For unit tests we need our own test clock: *)
-
-val timestamp : (unit -> float) ref
-val sleep : (float -> unit Lwt.t) ref

--- a/lib_cache/s.ml
+++ b/lib_cache/s.ml
@@ -52,10 +52,6 @@ module type BUILDER = sig
   val auto_cancel : bool
   (** [true] if an operation should be cancelled if it is no longer needed, or
       [false] to cancel only when the user explicitly requests it. *)
-
-  val level : t -> Key.t -> Current.Level.t
-  (** [level t k] provides an estimate of how risky / expensive this operation is.
-      This is useful to perform dry-runs, or limit to local-only effects, etc. *)
 end
 
 module type PUBLISHER = sig
@@ -86,8 +82,4 @@ module type PUBLISHER = sig
       then we decide to output a different value instead.
       If [true], the old operation will be cancelled immediately.
       If [false], the old operation will run to completion first. *)
-
-  val level : t -> Key.t -> Value.t -> Current.Level.t
-  (** [level t k v] provides an estimate of how risky / expensive this operation is.
-      This is useful to perform dry-runs, or limit to local-only effects, etc. *)
 end

--- a/lib_cache/s.ml
+++ b/lib_cache/s.ml
@@ -39,11 +39,10 @@ module type BUILDER = sig
 
   val build :
     switch:Current.Switch.t ->
-    set_running:(unit -> unit) ->
     t -> Current.Job.t -> Key.t ->
     Value.t Current.or_error Lwt.t
-  (** [build ~switch ~set_running t j k] builds [k].
-      Call [set_running] once any required resources have been acquired.
+  (** [build ~switch t j k] builds [k].
+      Call [Job.set_running j] once any required resources have been acquired.
       If the switch is turned off, the build should be cancelled.
       Log messages can be written to [j]. *)
 
@@ -75,6 +74,7 @@ module type PUBLISHER = sig
     switch:Current.Switch.t -> t -> Current.Job.t -> Key.t -> Value.t ->
     Outcome.t Current.or_error Lwt.t
   (** [publish ~switch t j k v] sets output [k] to value [v].
+      Call [Job.set_running j] once any required resources have been acquired.
       If the switch is turned off, the operation should be cancelled.
       Log messages can be written to [j]. *)
 

--- a/lib_cache/s.ml
+++ b/lib_cache/s.ml
@@ -42,7 +42,7 @@ module type BUILDER = sig
     t -> Current.Job.t -> Key.t ->
     Value.t Current.or_error Lwt.t
   (** [build ~switch t j k] builds [k].
-      Call [Job.set_running j] once any required resources have been acquired.
+      Call [Job.start j] once any required resources have been acquired.
       If the switch is turned off, the build should be cancelled.
       Log messages can be written to [j]. *)
 
@@ -74,7 +74,7 @@ module type PUBLISHER = sig
     switch:Current.Switch.t -> t -> Current.Job.t -> Key.t -> Value.t ->
     Outcome.t Current.or_error Lwt.t
   (** [publish ~switch t j k v] sets output [k] to value [v].
-      Call [Job.set_running j] once any required resources have been acquired.
+      Call [Job.start j] once any required resources have been acquired.
       If the switch is turned off, the operation should be cancelled.
       Log messages can be written to [j]. *)
 

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -3,6 +3,7 @@ open Lwt.Infix
 type t = {
   pull : bool;
   pool : unit Lwt_pool.t option;
+  timeout : Duration.t option;
 }
 
 let id = "docker-build"
@@ -57,9 +58,9 @@ let with_context ~switch ~job context fn =
   | `No_context -> Current.Process.with_tmpdir ~prefix:"build-context-" fn
   | `Git commit -> Current_git.with_checkout ~switch ~job commit fn
 
-let build ~switch { pull; pool } job key =
+let build ~switch { pull; pool; timeout } job key =
   use_pool pool @@ fun () ->
-  Current.Job.set_running job;
+  Current.Job.set_running ?timeout job;
   let { Key.commit; docker_context; dockerfile; squash } = key in
   with_context ~switch ~job commit @@ fun dir ->
   begin match dockerfile with

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -60,7 +60,7 @@ let with_context ~switch ~job context fn =
 
 let build ~switch { pull; pool; timeout } job key =
   use_pool pool @@ fun () ->
-  Current.Job.start ?timeout job >>= fun () ->
+  Current.Job.start ?timeout job ~level:Current.Level.Average >>= fun () ->
   let { Key.commit; docker_context; dockerfile; squash } = key in
   with_context ~switch ~job commit @@ fun dir ->
   begin match dockerfile with
@@ -87,5 +87,3 @@ let build ~switch { pull; pool; timeout } job key =
 let pp f key = Fmt.pf f "@[<v2>docker build %a@]" Key.pp key
 
 let auto_cancel = true
-
-let level _ _ = Current.Level.Average

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -60,7 +60,7 @@ let with_context ~switch ~job context fn =
 
 let build ~switch { pull; pool; timeout } job key =
   use_pool pool @@ fun () ->
-  Current.Job.set_running ?timeout job;
+  Current.Job.start ?timeout job >>= fun () ->
   let { Key.commit; docker_context; dockerfile; squash } = key in
   with_context ~switch ~job commit @@ fun dir ->
   begin match dockerfile with

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -57,9 +57,9 @@ let with_context ~switch ~job context fn =
   | `No_context -> Current.Process.with_tmpdir ~prefix:"build-context-" fn
   | `Git commit -> Current_git.with_checkout ~switch ~job commit fn
 
-let build ~switch ~set_running { pull; pool } job key =
+let build ~switch { pull; pool } job key =
   use_pool pool @@ fun () ->
-  set_running ();
+  Current.Job.set_running job;
   let { Key.commit; docker_context; dockerfile; squash } = key in
   with_context ~switch ~job commit @@ fun dir ->
   begin match dockerfile with

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -29,12 +29,12 @@ module Make (Host : S.HOST) = struct
     | `No_context -> Current.return `No_context
     | `Git commit -> Current.map (fun x -> `Git x) commit
 
-  let build ?schedule ?(squash=false) ?label ?dockerfile ?pool ~pull src =
+  let build ?schedule ?timeout ?(squash=false) ?label ?dockerfile ?pool ~pull src =
     Current.component "build%a" pp_sp_label label |>
     let> commit = get_build_context src
     and> dockerfile = Current.option_seq dockerfile in
     let dockerfile = option_map Dockerfile.string_of_t dockerfile in
-    BC.get ?schedule { Build.pull; pool } { Build.Key.commit; dockerfile; docker_context; squash }
+    BC.get ?schedule { Build.pull; pool; timeout } { Build.Key.commit; dockerfile; docker_context; squash }
 
   module RC = Current_cache.Make(Run)
 

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -17,8 +17,8 @@ module Value = Image
 
 let id = "docker-pull"
 
-let build ~switch ~set_running No_context job key =
-  set_running ();
+let build ~switch No_context job key =
+  Current.Job.set_running job;
   Current.Process.exec ~switch ~job (Key.cmd key) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -18,7 +18,7 @@ module Value = Image
 let id = "docker-pull"
 
 let build ~switch No_context job key =
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   Current.Process.exec ~switch ~job (Key.cmd key) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -18,7 +18,7 @@ module Value = Image
 let id = "docker-pull"
 
 let build ~switch No_context job key =
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
   Current.Process.exec ~switch ~job (Key.cmd key) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->
@@ -34,5 +34,3 @@ let build ~switch No_context job key =
 let pp f key = Cmd.pp f (Key.cmd key)
 
 let auto_cancel = false
-
-let level _ _ = Current.Level.Mostly_harmless

--- a/plugins/docker/push.ml
+++ b/plugins/docker/push.ml
@@ -34,6 +34,7 @@ let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
 let publish ~switch auth job key value =
+  Current.Job.set_running job;
   Current.Process.exec ~switch ~job (tag_cmd key value) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->

--- a/plugins/docker/push.ml
+++ b/plugins/docker/push.ml
@@ -34,7 +34,7 @@ let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
 let publish ~switch auth job key value =
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
   Current.Process.exec ~switch ~job (tag_cmd key value) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->
@@ -59,5 +59,3 @@ let pp f (key, value) =
     key.Key.tag
 
 let auto_cancel = false
-
-let level _auth _tag _value = Current.Level.Dangerous

--- a/plugins/docker/push.ml
+++ b/plugins/docker/push.ml
@@ -34,7 +34,7 @@ let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
 let publish ~switch auth job key value =
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   Current.Process.exec ~switch ~job (tag_cmd key value) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->

--- a/plugins/docker/push_manifest.ml
+++ b/plugins/docker/push_manifest.ml
@@ -38,7 +38,7 @@ let or_fail = function
   | Error (`Msg x) -> failwith x
 
 let publish ~switch auth job tag value =
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
   Current.Process.with_tmpdir ~prefix:"push-manifest" @@ fun config ->
   Bos.OS.File.write Fpath.(config / "config.json") {|{"experimental": "enabled"}|} |> or_fail;
   Current.Process.exec ~switch ~job (create_cmd ~config ~tag value) >>= function
@@ -57,5 +57,3 @@ let pp f (tag, value) =
   Fmt.pf f "push %s = %s" tag (Value.digest value)
 
 let auto_cancel = true
-
-let level _auth _tag _value = Current.Level.Dangerous

--- a/plugins/docker/push_manifest.ml
+++ b/plugins/docker/push_manifest.ml
@@ -38,6 +38,7 @@ let or_fail = function
   | Error (`Msg x) -> failwith x
 
 let publish ~switch auth job tag value =
+  Current.Job.set_running job;
   Current.Process.with_tmpdir ~prefix:"push-manifest" @@ fun config ->
   Bos.OS.File.write Fpath.(config / "config.json") {|{"experimental": "enabled"}|} |> or_fail;
   Current.Process.exec ~switch ~job (create_cmd ~config ~tag value) >>= function

--- a/plugins/docker/push_manifest.ml
+++ b/plugins/docker/push_manifest.ml
@@ -38,7 +38,7 @@ let or_fail = function
   | Error (`Msg x) -> failwith x
 
 let publish ~switch auth job tag value =
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   Current.Process.with_tmpdir ~prefix:"push-manifest" @@ fun config ->
   Bos.OS.File.write Fpath.(config / "config.json") {|{"experimental": "enabled"}|} |> or_fail;
   Current.Process.exec ~switch ~job (create_cmd ~config ~tag value) >>= function

--- a/plugins/docker/run.ml
+++ b/plugins/docker/run.ml
@@ -1,3 +1,5 @@
+open Lwt.Infix
+
 type t = No_context
 
 let id = "docker-run"
@@ -27,7 +29,7 @@ end
 module Value = Current.Unit
 
 let build ~switch No_context job key =
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   Current.Process.exec ~switch ~job (Key.cmd key)
 
 let pp = Key.pp

--- a/plugins/docker/run.ml
+++ b/plugins/docker/run.ml
@@ -29,11 +29,9 @@ end
 module Value = Current.Unit
 
 let build ~switch No_context job key =
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Average >>= fun () ->
   Current.Process.exec ~switch ~job (Key.cmd key)
 
 let pp = Key.pp
 
 let auto_cancel = true
-
-let level _ _ = Current.Level.Average

--- a/plugins/docker/run.ml
+++ b/plugins/docker/run.ml
@@ -26,8 +26,8 @@ end
 
 module Value = Current.Unit
 
-let build ~switch ~set_running No_context job key =
-  set_running ();
+let build ~switch No_context job key =
+  Current.Job.set_running job;
   Current.Process.exec ~switch ~job (Key.cmd key)
 
 let pp = Key.pp

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -21,6 +21,7 @@ module type DOCKER = sig
 
   val build :
     ?schedule:Current_cache.Schedule.t ->
+    ?timeout:Duration.t ->
     ?squash:bool ->
     ?label:string ->
     ?dockerfile:Dockerfile.t Current.t ->
@@ -29,6 +30,7 @@ module type DOCKER = sig
     source ->
     Image.t Current.t
   (** [build ~pull src] builds a Docker image from source.
+      @param timeout If set, abort builds that take longer than this.
       @param squash If set to [true], pass "--squash" to "docker build".
       @param dockerfile If present, this is used as the contents of the Dockerfile.
       @param pull If [true], always check for updates and pull the latest version.

--- a/plugins/docker/service.ml
+++ b/plugins/docker/service.ml
@@ -1,3 +1,5 @@
+open Lwt.Infix
+
 type t = No_context
 
 let id = "docker-service"
@@ -28,7 +30,7 @@ let cmd { Key.name; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["service"; "update"; "--image"; Image.hash image; name]
 
 let publish ~switch No_context job key value =
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   Current.Process.exec ~switch ~job (cmd key value)
 
 let pp f (key, value) =

--- a/plugins/docker/service.ml
+++ b/plugins/docker/service.ml
@@ -28,6 +28,7 @@ let cmd { Key.name; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["service"; "update"; "--image"; Image.hash image; name]
 
 let publish ~switch No_context job key value =
+  Current.Job.set_running job;
   Current.Process.exec ~switch ~job (cmd key value)
 
 let pp f (key, value) =

--- a/plugins/docker/service.ml
+++ b/plugins/docker/service.ml
@@ -30,12 +30,10 @@ let cmd { Key.name; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["service"; "update"; "--image"; Image.hash image; name]
 
 let publish ~switch No_context job key value =
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
   Current.Process.exec ~switch ~job (cmd key value)
 
 let pp f (key, value) =
   Cmd.pp f (cmd key value)
 
 let auto_cancel = false
-
-let level No_context _key _value = Current.Level.Dangerous

--- a/plugins/docker/tag.ml
+++ b/plugins/docker/tag.ml
@@ -1,3 +1,5 @@
+open Lwt.Infix
+
 let ( >>!= ) = Lwt_result.bind
 
 type t = No_context
@@ -30,7 +32,7 @@ let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
 let publish ~switch No_context job key value =
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   Current.Process.exec ~switch ~job (tag_cmd key value)
 
 let pp f (key, value) =

--- a/plugins/docker/tag.ml
+++ b/plugins/docker/tag.ml
@@ -30,6 +30,7 @@ let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
 let publish ~switch No_context job key value =
+  Current.Job.set_running job;
   Current.Process.exec ~switch ~job (tag_cmd key value)
 
 let pp f (key, value) =

--- a/plugins/docker/tag.ml
+++ b/plugins/docker/tag.ml
@@ -32,12 +32,10 @@ let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
 let publish ~switch No_context job key value =
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Average >>= fun () ->
   Current.Process.exec ~switch ~job (tag_cmd key value)
 
 let pp f (key, value) =
   Cmd.pp f (tag_cmd key value)
 
 let auto_cancel = false
-
-let level _auth _tag _value = Current.Level.Average

--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -1,3 +1,5 @@
+open Lwt.Infix
+
 type t = No_context
 
 let ( >>!= ) = Lwt_result.bind
@@ -31,7 +33,7 @@ let id = "git-clone"
 
 let build ~switch No_context job { Key.repo; gref } =
   Lwt_mutex.with_lock (repo_lock repo) @@ fun () ->
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   let local_repo = Cmd.local_copy repo in
   (* Ensure we have a local clone of the repository. *)
   begin

--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -33,7 +33,7 @@ let id = "git-clone"
 
 let build ~switch No_context job { Key.repo; gref } =
   Lwt_mutex.with_lock (repo_lock repo) @@ fun () ->
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
   let local_repo = Cmd.local_copy repo in
   (* Ensure we have a local clone of the repository. *)
   begin
@@ -48,5 +48,3 @@ let build ~switch No_context job { Key.repo; gref } =
 let pp f key = Fmt.pf f "git clone %a" Key.pp key
 
 let auto_cancel = false
-
-let level _ _ = Current.Level.Mostly_harmless

--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -29,9 +29,9 @@ let repo_lock repo =
 
 let id = "git-clone"
 
-let build ~switch ~set_running No_context job { Key.repo; gref } =
+let build ~switch No_context job { Key.repo; gref } =
   Lwt_mutex.with_lock (repo_lock repo) @@ fun () ->
-  set_running ();
+  Current.Job.set_running job;
   let local_repo = Cmd.local_copy repo in
   (* Ensure we have a local clone of the repository. *)
   begin

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -22,7 +22,7 @@ module Fetch = struct
   let build ~switch No_context job key =
     let { Commit_id.repo = remote_repo; gref; hash = _ } = key in
     Lwt_mutex.with_lock (Clone.repo_lock remote_repo) @@ fun () ->
-    Current.Job.set_running job;
+    Current.Job.start job >>= fun () ->
     let local_repo = Cmd.local_copy remote_repo in
     (* Ensure we have a local clone of the repository. *)
     begin

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -19,10 +19,10 @@ module Fetch = struct
 
   let id = "git-fetch"
 
-  let build ~switch ~set_running No_context job key =
+  let build ~switch No_context job key =
     let { Commit_id.repo = remote_repo; gref; hash = _ } = key in
     Lwt_mutex.with_lock (Clone.repo_lock remote_repo) @@ fun () ->
-    set_running ();
+    Current.Job.set_running job;
     let local_repo = Cmd.local_copy remote_repo in
     (* Ensure we have a local clone of the repository. *)
     begin

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -442,6 +442,7 @@ module Commit = struct
         Value.pp status
 
     let publish ~switch:_ t job key status =
+      Current.Job.set_running job;
       let {Key.commit; context} = key in
       let body = `Assoc (("context", `String context) :: Value.json_items status) in
       get_token t >>= function

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -442,7 +442,7 @@ module Commit = struct
         Value.pp status
 
     let publish ~switch:_ t job key status =
-      Current.Job.set_running job;
+      Current.Job.start job >>= fun () ->
       let {Key.commit; context} = key in
       let body = `Assoc (("context", `String context) :: Value.json_items status) in
       get_token t >>= function

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -431,8 +431,6 @@ module Commit = struct
 
     module Outcome = Current.Unit
 
-    let level _ _ _ = Current.Level.Above_average
-
     let auto_cancel = false
 
     let pp f ({ Key.commit; context }, status) =
@@ -442,7 +440,7 @@ module Commit = struct
         Value.pp status
 
     let publish ~switch:_ t job key status =
-      Current.Job.start job >>= fun () ->
+      Current.Job.start job ~level:Current.Level.Above_average >>= fun () ->
       let {Key.commit; context} = key in
       let body = `Assoc (("context", `String context) :: Value.json_items status) in
       get_token t >>= function

--- a/plugins/slack/post.ml
+++ b/plugins/slack/post.ml
@@ -9,7 +9,7 @@ module Value = Current.String
 module Outcome = Current.Unit
 
 let publish ~switch:_ t job _key message =
-  Current.Job.start job >>= fun () ->
+  Current.Job.start job ~level:Current.Level.Above_average >>= fun () ->
   let headers = Cohttp.Header.of_list [
       "Content-type", "application/json";
     ]
@@ -30,5 +30,3 @@ let publish ~switch:_ t job _key message =
 let pp f (key, value) = Fmt.pf f "Post %s: %s" key value
 
 let auto_cancel = false
-
-let level _t _k _v = Current.Level.Above_average

--- a/plugins/slack/post.ml
+++ b/plugins/slack/post.ml
@@ -9,7 +9,7 @@ module Value = Current.String
 module Outcome = Current.Unit
 
 let publish ~switch:_ t job _key message =
-  Current.Job.set_running job;
+  Current.Job.start job >>= fun () ->
   let headers = Cohttp.Header.of_list [
       "Content-type", "application/json";
     ]

--- a/plugins/slack/post.ml
+++ b/plugins/slack/post.ml
@@ -8,7 +8,8 @@ module Key = Current.String
 module Value = Current.String
 module Outcome = Current.Unit
 
-let publish ~switch:_ t _job _key message =
+let publish ~switch:_ t job _key message =
+  Current.Job.set_running job;
   let headers = Cohttp.Header.of_list [
       "Content-type", "application/json";
     ]

--- a/test/plugins/docker/current_docker_test.ml
+++ b/test/plugins/docker/current_docker_test.ml
@@ -56,7 +56,7 @@ module Run = struct
   let pp = Key.pp
 
   let build ~switch No_context job (key : Key.t) =
-    Current.Job.set_running job;
+    Current.Job.start job >>= fun () ->
     let ready, set_ready = Lwt.wait () in
     containers := Containers.add key set_ready !containers;
     Current.Switch.add_hook_or_exec switch (function
@@ -99,7 +99,7 @@ module Push = struct
   let pp f k = Fmt.pf f "docker push %a" Key.pp k
 
   let build ~switch:_ No_context job _key =
-    Current.Job.set_running job;
+    Current.Job.start job >>= fun () ->
     Lwt.return (Ok ())
 
   let auto_cancel = false

--- a/test/plugins/docker/current_docker_test.ml
+++ b/test/plugins/docker/current_docker_test.ml
@@ -55,8 +55,8 @@ module Run = struct
 
   let pp = Key.pp
 
-  let build ~switch ~set_running No_context _job (key : Key.t) =
-    set_running ();
+  let build ~switch No_context job (key : Key.t) =
+    Current.Job.set_running job;
     let ready, set_ready = Lwt.wait () in
     containers := Containers.add key set_ready !containers;
     Current.Switch.add_hook_or_exec switch (function
@@ -98,8 +98,8 @@ module Push = struct
 
   let pp f k = Fmt.pf f "docker push %a" Key.pp k
 
-  let build ~switch:_ ~set_running No_context _job _key =
-    set_running ();
+  let build ~switch:_ No_context job _key =
+    Current.Job.set_running job;
     Lwt.return (Ok ())
 
   let auto_cancel = false

--- a/test/plugins/docker/current_docker_test.ml
+++ b/test/plugins/docker/current_docker_test.ml
@@ -56,7 +56,7 @@ module Run = struct
   let pp = Key.pp
 
   let build ~switch No_context job (key : Key.t) =
-    Current.Job.start job >>= fun () ->
+    Current.Job.start job ~level:Current.Level.Average >>= fun () ->
     let ready, set_ready = Lwt.wait () in
     containers := Containers.add key set_ready !containers;
     Current.Switch.add_hook_or_exec switch (function
@@ -71,8 +71,6 @@ module Run = struct
     ready
 
   let auto_cancel = true
-
-  let level _ _ = Current.Level.Average
 end
 
 module Run_cache = Current_cache.Make(Run)
@@ -99,12 +97,10 @@ module Push = struct
   let pp f k = Fmt.pf f "docker push %a" Key.pp k
 
   let build ~switch:_ No_context job _key =
-    Current.Job.start job >>= fun () ->
+    Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
     Lwt.return (Ok ())
 
   let auto_cancel = false
-
-  let level _ _ = Current.Level.Dangerous
 end
 
 module Push_cache = Current_cache.Make(Push)

--- a/test/plugins/git/current_git_test.ml
+++ b/test/plugins/git/current_git_test.ml
@@ -1,3 +1,5 @@
+open Lwt.Infix
+
 open Current.Syntax
 
 let src = Logs.Src.create "test.git" ~doc:"OCurrent test git plugin"
@@ -43,7 +45,7 @@ module Clone = struct
   let pp f key = Fmt.pf f "git clone %S" key.Commit.repo
 
   let build ~switch:_ No_context job (key : Key.t) =
-    Current.Job.set_running job;
+    Current.Job.start job >>= fun () ->
     let ready, set_ready = Lwt.wait () in
     state := RepoMap.add key.Commit.repo set_ready !state;
     ready

--- a/test/plugins/git/current_git_test.ml
+++ b/test/plugins/git/current_git_test.ml
@@ -42,8 +42,8 @@ module Clone = struct
 
   let pp f key = Fmt.pf f "git clone %S" key.Commit.repo
 
-  let build ~switch:_ ~set_running No_context _job (key : Key.t) =
-    set_running ();
+  let build ~switch:_ No_context job (key : Key.t) =
+    Current.Job.set_running job;
     let ready, set_ready = Lwt.wait () in
     state := RepoMap.add key.Commit.repo set_ready !state;
     ready

--- a/test/plugins/git/current_git_test.ml
+++ b/test/plugins/git/current_git_test.ml
@@ -45,14 +45,12 @@ module Clone = struct
   let pp f key = Fmt.pf f "git clone %S" key.Commit.repo
 
   let build ~switch:_ No_context job (key : Key.t) =
-    Current.Job.start job >>= fun () ->
+    Current.Job.start job ~level:Current.Level.Average >>= fun () ->
     let ready, set_ready = Lwt.wait () in
     state := RepoMap.add key.Commit.repo set_ready !state;
     ready
 
   let auto_cancel = true
-
-  let level _ _ = Current.Level.Average
 end
 
 module C = Current_cache.Make(Clone)

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -20,7 +20,7 @@ module Build = struct
   let pp = Fmt.string
 
   let build ~switch:_ t job key =
-    Current.Job.set_running job;
+    Current.Job.start job >>= fun () ->
     if Builds.mem key !t then Fmt.failwith "Already building %s!" key;
     let finished, set_finished = Lwt.wait () in
     t := Builds.add key set_finished !t;
@@ -229,7 +229,7 @@ module Publish = struct
     Logs.info (fun f -> f "test_cache.publish");
     assert (key = "foo");
     assert (t.set_finished = None);
-    Current.Job.set_running job;
+    Current.Job.start job >>= fun () ->
     let finished, set_finished = Lwt.wait () in
     t.set_finished <- Some set_finished;
     t.state <- t.state ^ "-changing";

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -20,15 +20,13 @@ module Build = struct
   let pp = Fmt.string
 
   let build ~switch:_ t job key =
-    Current.Job.start job >>= fun () ->
+    Current.Job.start job ~level:Current.Level.Average >>= fun () ->
     if Builds.mem key !t then Fmt.failwith "Already building %s!" key;
     let finished, set_finished = Lwt.wait () in
     t := Builds.add key set_finished !t;
     finished
 
   let auto_cancel = true
-
-  let level _ _ = Current.Level.Average
 end
 
 module BC = Current_cache.Make(Build)
@@ -229,7 +227,7 @@ module Publish = struct
     Logs.info (fun f -> f "test_cache.publish");
     assert (key = "foo");
     assert (t.set_finished = None);
-    Current.Job.start job >>= fun () ->
+    Current.Job.start job ~level:Current.Level.Average >>= fun () ->
     let finished, set_finished = Lwt.wait () in
     t.set_finished <- Some set_finished;
     t.state <- t.state ^ "-changing";
@@ -247,8 +245,6 @@ module Publish = struct
 
   let pp f (k, v) =
     Fmt.pf f "Set %s to %s" k v
-
-  let level _ _ _ = Current.Level.Average
 
   let auto_cancel = false
 


### PR DESCRIPTION
- Converted `set_running` callback argument to `Job.start` function. This cleans up the API a bit. It also allows adding extra arguments to the function without breaking existing code (since function types with optional arguments cannot be inferred).
- Publishers are now required to call `Job.start` too. This allows them to remain in the ready state while waiting for resources.
- Pass a timeout to `Job.start` to cancel the job automatically after that long.
-  Move level threshold to `Job.start`. This simplifies the cache interface and also allows builders to log a plan of what they will do before waiting for confirmation.
- `Docker.build` shows the `Dockerfile` it will use before confirming.