### PR TITLE
Add auto_release timeout for confirm threshold

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -5,17 +5,32 @@ type t = {
   level_cond : unit Lwt_condition.t;
 }
 
-let v ?confirm () =
-  let level_cond = Lwt_condition.create () in
-  { confirm; level_cond }
-
-let default = v ()
-
 let set_confirm t level =
+  Log.info (fun f -> f "Confirmation threshold is now %a" (Fmt.Dump.option Level.pp) level);
   t.confirm <- level;
   Lwt_condition.broadcast t.level_cond ()
 
 let get_confirm t = t.confirm
+
+(* If the level isn't changed manually within [duration], remove limiter. *)
+let slow_start_thread t duration =
+  Lwt.async
+    (fun () ->
+       let changed = Lwt_condition.wait t.level_cond in
+       Lwt.choose [Lwt_unix.sleep (Duration.to_f duration); changed] >|= fun () ->
+       if Lwt.state changed = Lwt.Sleep then (
+         Log.info (fun f -> f "Slow start period over; removing limiter");
+         set_confirm t None;
+       )
+    )
+
+let v ?auto_release ?confirm () =
+  let level_cond = Lwt_condition.create () in
+  let t = { confirm; level_cond } in
+  Option.iter (slow_start_thread t) auto_release;
+  t
+
+let default = v ()
 
 let rec confirmed l t =
   match t.confirm with
@@ -34,6 +49,16 @@ let cmdliner_confirm =
   Arg.info ~doc:"Confirm before starting operations at or above this level."
     ["confirm"]
 
+let auto_release =
+  Arg.value @@
+  Arg.(opt (some int)) None @@
+  Arg.info
+    ~doc:"Remove confirm threshold after this many seconds from start-up"
+    ~docv:"SEC"
+    ["confirm-auto-release"]
+
 let cmdliner =
-  let make confirm = v ?confirm () in
-  Term.(const make $ Arg.value cmdliner_confirm)
+  let make auto_release confirm =
+    let auto_release = Option.map Duration.of_sec auto_release in
+    v ?auto_release ?confirm () in
+  Term.(const make $ auto_release $ Arg.value cmdliner_confirm)

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -5,9 +5,10 @@ module Level = Level
 module Config : sig
   type t
 
-  val v : ?confirm:Level.t -> unit -> t
+  val v : ?auto_release:Duration.t -> ?confirm:Level.t -> unit -> t
   (** A new configuration.
-      @param confirm : confirm before performing operations at or above this level. *)
+      @param auto_release Remove confirmation requirement this period (unless changed manually first).
+      @param confirm Confirm before performing operations at or above this level. *)
 
   val set_confirm : t -> Level.t option -> unit
   (** Change the [confirm] setting. Existing jobs waiting for confirmation


### PR DESCRIPTION
This allows you to start the service with confirmation on for testing, but automatically switch to full speed after a bit if the admin doesn't do anything (e.g. because the service restarted automatically after a power-cut).