### PR TITLE
Improve error reporting

### DIFF
--- a/lib/current.mli
+++ b/lib/current.mli
@@ -276,14 +276,20 @@ end
 
 module Process : sig
   val exec :
-    ?switch:Switch.t -> ?stdin:string -> job:Job.t -> Lwt_process.command ->
+    ?switch:Switch.t -> ?stdin:string ->
+    ?pp_error_command:(Format.formatter -> unit) ->
+    job:Job.t -> Lwt_process.command ->
     unit or_error Lwt.t
   (** [exec ~job cmd] uses [Lwt_process] to run [cmd], with output to [job]'s log.
       @param switch If this is turned off, the process is terminated.
-      @param stdin Data to write to stdin before closing it. *)
+      @param stdin Data to write to stdin before closing it.
+      @param pp_error_command Format the command for an error message.
+        The default is to print "Command $cmd". *)
 
   val check_output :
-    ?switch:Switch.t -> ?cwd:Fpath.t -> ?stdin:string -> job:Job.t -> Lwt_process.command ->
+    ?switch:Switch.t -> ?cwd:Fpath.t -> ?stdin:string ->
+    ?pp_error_command:(Format.formatter -> unit) ->
+    job:Job.t -> Lwt_process.command ->
     string or_error Lwt.t
   (** Like [exec], but return the child's stdout as a string rather than writing it to the log. *)
 

--- a/lib/process.mli
+++ b/lib/process.mli
@@ -1,9 +1,13 @@
 val exec :
-  ?switch:Switch.t -> ?stdin:string -> job:Job.t -> Lwt_process.command ->
+  ?switch:Switch.t -> ?stdin:string ->
+  ?pp_error_command:(Format.formatter -> unit) ->
+  job:Job.t -> Lwt_process.command ->
   unit Current_term.S.or_error Lwt.t
 
 val check_output :
-  ?switch:Switch.t -> ?cwd:Fpath.t -> ?stdin:string -> job:Job.t -> Lwt_process.command ->
+  ?switch:Switch.t -> ?cwd:Fpath.t -> ?stdin:string ->
+  ?pp_error_command:(Format.formatter -> unit) ->
+  job:Job.t -> Lwt_process.command ->
   string Current_term.S.or_error Lwt.t
 
 val with_tmpdir : ?prefix:string -> (Fpath.t -> 'a Lwt.t) -> 'a Lwt.t

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -7,7 +7,7 @@ module Make (Job : sig type id end) : sig
     | Blocked
     | Active of Output.active
     | Pass
-    | Fail
+    | Fail of string
 
   type env
 
@@ -22,7 +22,7 @@ module Make (Job : sig type id end) : sig
 
   val blocked    : env:env -> unit -> t
   val return     : env:env -> string option -> t
-  val fail       : env:env -> unit -> t
+  val fail       : env:env -> string -> t
   val state      : env:env -> t -> t
   val catch      : env:env -> t -> t
   val active     : env:env -> Output.active -> t

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -23,6 +23,7 @@ module Make (Job : sig type id end) : sig
   val blocked    : env:env -> unit -> t
   val return     : env:env -> string option -> t
   val fail       : env:env -> string -> t
+  val map_failed : env:env -> t -> string -> t
   val state      : env:env -> t -> t
   val catch      : env:env -> t -> t
   val active     : env:env -> Output.active -> t

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -108,7 +108,7 @@ module Make (Input : S.INPUT) = struct
     | fn -> make x.md fn
     | exception ex ->
       let msg = msg_of_exn ex in
-      make (An.fail ~env msg) (Dyn.fail msg)
+      make (An.map_failed ~env x.md msg) (Dyn.fail msg)
 
   let ignore_value x = map ignore x
 

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -60,7 +60,7 @@ module Make (Input : S.INPUT) = struct
 
   let fail msg =
     cache @@ fun ~env _ctx ->
-    make (An.fail ~env ()) (Dyn.fail msg)
+    make (An.fail ~env msg) (Dyn.fail msg)
 
   let state t =
     cache @@ fun ~env ctx ->
@@ -83,7 +83,7 @@ module Make (Input : S.INPUT) = struct
     let x = x ctx in
     let md = An.bind ~env ?info x.md in
     match Dyn.run x.fn with
-    | Error (`Msg e) -> make (md An.Fail) (Dyn.fail e)
+    | Error (`Msg e) -> make (md (An.Fail e)) (Dyn.fail e)
     | Error (`Active a) -> make (md (An.Active a)) (Dyn.active a)
     | Ok y ->
       let md = md An.Pass in
@@ -91,17 +91,24 @@ module Make (Input : S.INPUT) = struct
       let r = f2 ctx in
       An.set_state md (
         match Dyn.run r.fn with
-        | Error (`Msg _) -> An.Fail
+        | Error (`Msg e) -> An.Fail e
         | Error (`Active a) -> An.Active a
         | Ok _ -> An.Pass
       );
       r
 
+  let msg_of_exn = function
+    | Failure m -> m
+    | ex -> Printexc.to_string ex
+
   let map f x =
-    cache @@ fun ~env:_ ctx ->
+    cache @@ fun ~env ctx ->
     let x = x ctx in
-    let fn = Dyn.map f x.fn in
-    make x.md fn
+    match Dyn.map f x.fn with
+    | fn -> make x.md fn
+    | exception ex ->
+      let msg = msg_of_exn ex in
+      make (An.fail ~env msg) (Dyn.fail msg)
 
   let ignore_value x = map ignore x
 
@@ -118,7 +125,7 @@ module Make (Input : S.INPUT) = struct
     let x = x ctx in
     let md = An.bind_input ~env ~info x.md in
     match Dyn.run x.fn with
-    | Error (`Msg e) -> make (md An.Fail) (Dyn.fail e)
+    | Error (`Msg e) -> make (md (An.Fail e)) (Dyn.fail e)
     | Error (`Active a) -> make (md (An.Active a)) (Dyn.active a)
     | Ok y ->
       let md = md An.Pass in
@@ -126,7 +133,7 @@ module Make (Input : S.INPUT) = struct
       let v, id = Input.get ctx.user_env input in
       An.set_state md ?id (
         match v with
-        | Error (`Msg _) -> An.Fail
+        | Error (`Msg e) -> An.Fail e
         | Error (`Active a) -> An.Active a
         | Ok _ -> An.Pass
       );
@@ -214,8 +221,9 @@ module Make (Input : S.INPUT) = struct
         let x = f () ctx in
         Dyn.run x.fn, x.md
       with ex ->
-        let fn = Dyn.fail (Printexc.to_string ex) |> Dyn.run in
-        let md = An.fail ~env:default_env () in
+        let msg = Printexc.to_string ex in
+        let fn = Dyn.fail msg |> Dyn.run in
+        let md = An.fail ~env:default_env msg in
         fn, md
   end
 

--- a/lib_term/dot.ml
+++ b/lib_term/dot.ml
@@ -4,13 +4,14 @@ let list_bind f x =
 let pp_option f (name, v) =
   Fmt.pf f "%s=%S" name v
 
-let node f ?style ?shape ?bg ?url i label =
+let node f ?style ?shape ?bg ?url ?tooltip i label =
   let attrs = [
     "label", Some label;
     "fillcolor", bg;
     "style", style;
     "shape", shape;
     "URL", url;
+    "tooltip", tooltip;
     "target", (if url = None then None else Some "_top");
   ] |> list_bind (function
       | _, None -> []

--- a/lib_term/dot.mli
+++ b/lib_term/dot.mli
@@ -1,6 +1,6 @@
 (* Utilties for generating dot files. *)
 
-val node : Format.formatter -> ?style:string -> ?shape:string -> ?bg:string -> ?url:string -> int -> string -> unit
+val node : Format.formatter -> ?style:string -> ?shape:string -> ?bg:string -> ?url:string -> ?tooltip:string -> int -> string -> unit
 val edge : Format.formatter -> ?style:string -> ?color:string -> int -> int -> unit
 
 val begin_cluster : Format.formatter -> int -> unit

--- a/lib_term/dyn.ml
+++ b/lib_term/dyn.ml
@@ -18,9 +18,7 @@ let bind x f =
 let map f x =
   match x with
   | Error _ as e -> e
-  | Ok y ->
-    try Ok (f y)
-    with ex -> Error (`Msg (Printexc.to_string ex))
+  | Ok y -> Ok (f y)
 
 let pair a b =
   match a, b with

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -2,14 +2,6 @@ open Tyxml.Html
 
 let html_to_string = Fmt.to_to_string (Tyxml.Html.pp ())
 
-let string_of_watches = Fmt.to_to_string Current.Engine.pp_metadata
-
-let render_watches w =
-  li [txt (string_of_watches w)]
-
-let render_job (id, _) =
-  li [txt (Fmt.to_to_string Current.Job.pp_id id)]
-
 let render_result = function
   | Ok () -> [txt "Success!"]
   | Error (`Active `Ready) -> [txt "Ready..."]
@@ -56,7 +48,7 @@ let settings config =
 
 let dashboard engine =
   let config = Current.Engine.config engine in
-  let { Current.Engine.value; analysis = _; watches; jobs } = Current.Engine.state engine in
+  let { Current.Engine.value; analysis = _; watches = _; jobs = _ } = Current.Engine.state engine in
   template [
     div [
       object_ ~a:[a_data "/pipeline.svg"] [txt "Pipeline diagram"];
@@ -65,11 +57,4 @@ let dashboard engine =
     p (render_result value);
     h2 [txt "Settings"];
     settings config;
-    h2 [txt "Debugging"];
-    details (summary [txt "Debugging information"]) [
-      h2 [txt "Jobs"];
-      ul (List.map render_job (Current.Job_map.bindings jobs));
-      h2 [txt "Watches"];
-      ul (List.map render_watches watches);
-    ];
   ]

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -77,7 +77,8 @@ let build ~switch { pull; pool; timeout } job key =
                                           ["--iidfile";
                                            Fpath.to_string iidfile; "--";
                                            Fpath.to_string dir] in
-  Current.Process.exec ~switch ?stdin:dockerfile ~job cmd >|= function
+  let pp_error_command f = Fmt.string f "Docker build" in
+  Current.Process.exec ~switch ?stdin:dockerfile ~pp_error_command ~job cmd >|= function
   | Error _ as e -> e
   | Ok () ->
     Bos.OS.File.read iidfile |> Stdlib.Result.map @@ fun hash ->

--- a/test/expected/v1c.3.dot
+++ b/test/expected/v1c.3.dot
@@ -6,6 +6,6 @@ digraph pipeline {
   n3 -> n2
   n1 [label="build",fillcolor="#90ee90",style="filled"]
   n2 -> n1
-  n0 [label="docker run make test",fillcolor="#ff4500",style="filled"]
+  n0 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Cancelled"]
   n1 -> n0
   }

--- a/test/expected/v3.3.dot
+++ b/test/expected/v3.3.dot
@@ -6,7 +6,7 @@ digraph pipeline {
   n9 -> n8
   n7 [label="build-win",fillcolor="#90ee90",style="filled"]
   n8 -> n7
-  n6 [label="docker run make test",fillcolor="#ff4500",style="filled"]
+  n6 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Missing DLL"]
   n7 -> n6
   n11 [label="build-mac",fillcolor="#90ee90",style="filled"]
   n8 -> n11
@@ -16,21 +16,21 @@ digraph pipeline {
   n8 -> n13
   n12 [label="docker run make test",fillcolor="#90ee90",style="filled"]
   n13 -> n12
-  n3 [label="",fillcolor="#ff4500",style="filled",shape="circle"]
+  n3 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
   n12 -> n3 [style="dashed"]
   n10 -> n3 [style="dashed"]
   n6 -> n3 [style="dashed"]
   n7 -> n3
   n2 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
   n3 -> n2
-  n15 [label="",fillcolor="#ff4500",style="filled",shape="circle"]
+  n15 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
   n12 -> n15 [style="dashed"]
   n10 -> n15 [style="dashed"]
   n6 -> n15 [style="dashed"]
   n11 -> n15
   n14 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
   n15 -> n14
-  n17 [label="",fillcolor="#ff4500",style="filled",shape="circle"]
+  n17 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
   n12 -> n17 [style="dashed"]
   n10 -> n17 [style="dashed"]
   n6 -> n17 [style="dashed"]

--- a/test/expected/v4.3.dot
+++ b/test/expected/v4.3.dot
@@ -4,12 +4,12 @@ digraph pipeline {
   n3 [label="head",fillcolor="#90ee90",style="filled"]
   n2 [label="fetch",fillcolor="#90ee90",style="filled"]
   n3 -> n2
-  n1 [label="custom-build",fillcolor="#ff4500",style="filled"]
+  n1 [label="custom-build",fillcolor="#ff4500",style="filled",tooltip="Failed"]
   n2 -> n1
   n4 [label="build",fillcolor="#90ee90",style="filled"]
   n1 -> n4
   n1 -> n4
-  n0 [label="docker run make test",fillcolor="#ff4500",style="filled"]
+  n0 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Failed"]
   n4 -> n0
   n1 -> n0
   }


### PR DESCRIPTION
- Show error message in tooltip for failed nodes.
- Report a more friendly error for Docker build failures.
- Show failed map operations in their own box.

Also, remove Debugging section from web UI (it wasn't useful).