### PR TITLE
Add Cap'n Proto RPC plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ svg
 var
 pipeline.dot
 pipeline.svg
+engine.capnp
+secret-key.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam2:4.08
-RUN sudo apt-get update && sudo apt-get install graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN git pull origin master && git reset --hard 8bc187ff7168b47537d5bbd9b330a90ed90830ad && opam update
+FROM ocurrent/opam:debian-10-ocaml-4.08
+RUN sudo apt-get update && sudo apt-get install capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 52074acae8ef1871ad7623cc5c04790ef6f1b988 && opam update
 ADD --chown=opam *.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only -t .

--- a/current_examples.opam
+++ b/current_examples.opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocaml-ci/current"
+bug-reports: "https://github.com/ocaml-ci/current/issues"
+dev-repo: "git+https://github.com/ocaml-ci/current.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt"
+  "lwt"
+  "cmdliner"
+  "duration"
+  "current" {= version}
+  "current_web" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_docker" {= version}
+  "current_rpc" {= version}
+  "capnp-rpc-unix" {>= "0.3.3"}
+  "dune" {build}
+]

--- a/current_rpc.opam
+++ b/current_rpc.opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocaml-ci/current"
+bug-reports: "https://github.com/ocaml-ci/current/issues"
+dev-repo: "git+https://github.com/ocaml-ci/current.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-lwt" {>= "0.3.3"}
+  "fpath"
+  "dune" {build}
+]

--- a/examples/dune
+++ b/examples/dune
@@ -1,11 +1,20 @@
 (executables
-  (names docker_build_local build_matrix docker_service github github_app)
+  (public_names docker_build_local
+                docker_service
+                build_matrix
+                github
+                github_app
+                rpc_server
+                rpc_client)
+  (package current_examples)
   (libraries current
              current_web
              current_docker
              current_git
              current_github
              current_fs
+             current_rpc
+             capnp-rpc-unix
              lwt.unix
              logs.fmt
              fmt.tty))

--- a/examples/logging.ml
+++ b/examples/logging.ml
@@ -30,9 +30,9 @@ let reporter =
   in
   { Logs.report = report }
 
-let init () =
+let init ?(level=Logs.Info) () =
   Fmt_tty.setup_std_outputs ();
-  Logs.(set_level (Some Info));
+  Logs.set_level (Some level);
   Logs.set_reporter reporter
 
 let with_dot ~dotfile f () =
@@ -48,7 +48,7 @@ let with_dot ~dotfile f () =
 
 let run x =
   match Lwt_main.run x with
-  | Ok _ as r -> r
+  | Ok () -> Ok ()
   | Error (`Msg m) as e ->
     Logs.err (fun f -> f "%a" Fmt.lines m);
     e

--- a/examples/logging.mli
+++ b/examples/logging.mli
@@ -1,4 +1,4 @@
-val init : unit -> unit
+val init : ?level:Logs.level -> unit -> unit
 (** Initialise the Logs library with some sensible defaults. *)
 
 val with_dot :
@@ -8,5 +8,5 @@ val with_dot :
 (** [with_dot ~dotfile pipeline] wraps [pipeline] to keep a dot diagram in
     [dotfile] showing its current state. *)
 
-val run : 'a Current.or_error Lwt.t -> 'a Current.or_error
+val run : unit Current.or_error Lwt.t -> unit Current.or_error
 (** [run x] is like [Lwt_main.run x], but logs the returned error, if any. *)

--- a/examples/rpc_client.ml
+++ b/examples/rpc_client.ml
@@ -5,16 +5,16 @@
 
    If run without further arguments, it queries the server and displays a list of active jobs, e.g.
 
-   $ rpc_client.exe ./engine.capnp
-   2019-09-18/155957-docker-build-37304d.log
-   2019-09-18/160916-docker-run-ac2ac8.log
+   $ dune exec -- rpc_client ./engine.capnp
+   2019-09-19/103850-docker-build-11b894
+   2019-09-19/104747-docker-run-01a31e
 
    With a job ID, it shows information about that job:
 
-   $ rpc_client.exe ./engine.capnp 2019-09-18/155957-docker-build-37304d.log
-   Job "2019-09-18/155957-docker-build-37304d.log":
+   $ dune exec -- rpc_client ./engine.capnp 2019-09-19/103850-docker-build-11b894
+   Job "2019-09-19/103850-docker-build-11b894":
      Description: docker build {
-                                 "commit": "d28bfc9f7af4ebbf9b349b04ee5cb96bfa71e108",
+                                 "commit": "946ce0334a15251459d1821c2b63e240d2760106",
                                  "dockerfile": null,
                                  "docker_context": null,
                                  "squash": false
@@ -24,7 +24,7 @@
 
    You can also pass the method as a further argument, e.g.
 
-   $ rpc_client.exe ./engine.capnp 2019-09-18/155957-docker-build-37304d.log rebuild
+   $ dune exec -- rpc_client ./engine.capnp 2019-09-19/103850-docker-build-11b894 rebuild
    Rebuild scheduled
 *)
 

--- a/examples/rpc_client.ml
+++ b/examples/rpc_client.ml
@@ -1,0 +1,125 @@
+(* Run this to connect to the server in "rpc_server.ml".
+
+   The first argument is the path to the engine.capnp file written by the server.
+   This file tells the client how to connect and gives it the secret token to allow access.
+
+   If run without further arguments, it queries the server and displays a list of active jobs, e.g.
+
+   $ rpc_client.exe ./engine.capnp
+   2019-09-18/155957-docker-build-37304d.log
+   2019-09-18/160916-docker-run-ac2ac8.log
+
+   With a job ID, it shows information about that job:
+
+   $ rpc_client.exe ./engine.capnp 2019-09-18/155957-docker-build-37304d.log
+   Job "2019-09-18/155957-docker-build-37304d.log":
+     Description: docker build {
+                                 "commit": "d28bfc9f7af4ebbf9b349b04ee5cb96bfa71e108",
+                                 "dockerfile": null,
+                                 "docker_context": null,
+                                 "squash": false
+                               } (completed)
+     Can cancel: false
+     Can rebuild: true
+
+   You can also pass the method as a further argument, e.g.
+
+   $ rpc_client.exe ./engine.capnp 2019-09-18/155957-docker-build-37304d.log rebuild
+   Rebuild scheduled
+*)
+
+open Lwt.Infix
+open Capnp_rpc_lwt
+
+let () = Logging.init ~level:Logs.Warning ()
+
+let list_jobs engine =
+  Current_rpc.Engine.active_jobs engine |> Lwt_result.map @@ fun jobs ->
+  List.iter print_endline jobs
+
+let print_ensure_endline s =
+  let l = String.length s in
+  if l > 0 && s.[l - 1] <> '\n' then print_endline s
+  else print_string s
+
+let show_log job =
+  Current_rpc.Job.log job |> Lwt_result.map print_ensure_endline
+
+let show_status job =
+  Current_rpc.Job.status job |> Lwt_result.map @@
+  fun { Current_rpc.Job.id; description; can_cancel; can_rebuild } ->
+  Fmt.pr "@[<v2>Job %S:@,\
+          Description: @[%a@]@,\
+          Can cancel: %b@,\
+          Can rebuild: %b@]@."
+    id
+    Fmt.lines description
+    can_cancel
+    can_rebuild
+
+let cancel job =
+  Current_rpc.Job.cancel job |> Lwt_result.map @@ fun () ->
+  Fmt.pr "Cancelled@."
+
+let rebuild job =
+  Current_rpc.Job.rebuild job |> Lwt_result.map @@ fun () ->
+  Fmt.pr "Rebuild scheduled@."
+
+let main ?job_id ~job_op engine_url =
+  let vat = Capnp_rpc_unix.client_only_vat () in
+  let sr = Capnp_rpc_unix.Vat.import_exn vat engine_url in
+  Sturdy_ref.connect_exn sr >>= fun engine ->
+  match job_id with
+  | None -> list_jobs engine
+  | Some job_id ->
+    let job = Current_rpc.Engine.job engine job_id in
+    Lwt.finalize
+      (fun () -> job_op job)
+      (fun () -> Capability.dec_ref job; Lwt.return_unit)
+
+(* Command-line parsing *)
+
+open Cmdliner
+
+let cap =
+  Arg.required @@
+  Arg.pos 0 Arg.(some Capnp_rpc_unix.sturdy_uri) None @@
+  Arg.info
+    ~doc:"The engine.capnp file."
+    ~docv:"CAP"
+    []
+
+let job =
+  Arg.value @@
+  Arg.pos 1 Arg.(some string) None @@
+  Arg.info
+    ~doc:"The job ID to act upon. If not given, it shows a list of active job IDs."
+    ~docv:"JOB"
+    []
+
+let job_op =
+  let ops = [
+    "log", show_log;
+    "status", show_status;
+    "cancel", cancel;
+    "rebuild", rebuild;
+  ] in
+  Arg.value @@
+  Arg.pos 2 Arg.(enum ops) show_status @@
+  Arg.info
+    ~doc:"The operation to perform (log, status, cancel or rebuild)."
+    ~docv:"METHOD"
+    []
+
+let cmd =
+  let doc = "Client for rpc_server.ml" in
+  let main engine job_id job_op =
+    match Lwt_main.run (main ?job_id ~job_op engine) with
+    | Ok () -> ()
+    | Error `Capnp ex -> Fmt.epr "%a@." Capnp_rpc.Error.pp ex; exit 1
+    | Error `Msg m -> Fmt.epr "%s@." m; exit 1
+  in
+  Term.(const main $ cap $ job $ job_op),
+  Term.info "rpc_client" ~doc
+
+let () = Term.(exit @@ eval cmd)

--- a/examples/rpc_server.ml
+++ b/examples/rpc_server.ml
@@ -1,0 +1,76 @@
+(* This is similar to docker_build_local.ml, but exposes a Cap'n Proto endpoint
+   so that it can be controlled remotely.
+
+   Run this as e.g.
+
+   dune exec -- ./examples/rpc_server.exe \
+      --capnp-secret-key-file=secret-key.pem \
+      --capnp-listen-address=unix:/tmp/ocurrent.sock
+
+   This will write out a "./engine.capnp" file, which clients
+   can use to connect. See rpc_client.ml for an example. *)
+
+open Lwt.Infix
+
+module Git = Current_git
+module Docker = Current_docker.Default
+module Rpc = Current_rpc.Impl(Current)
+
+let () = Logging.init ()
+
+(* Where we write the connection details containing the connection address and
+   authorisation token. *)
+let cap_file = "engine.capnp"
+
+let pull = false    (* Whether to check for updates using "docker build --pull" *)
+
+let timeout = Duration.of_min 50    (* Max build time *)
+
+(* Run "docker build" on the latest commit in Git repository [repo]. *)
+let pipeline ~repo () =
+  let src = Git.Local.head_commit repo in
+  let image = Docker.build ~pull ~timeout (`Git src) in
+  Docker.run image ~args:["dune"; "exec"; "--"; "examples/docker_build_local.exe"; "--help"]
+
+let main config mode capnp repo =
+  let repo = Git.Local.v (Fpath.v repo) in
+  let engine = Current.Engine.create ~config (pipeline ~repo) in
+  let service_id = Capnp_rpc_unix.Vat_config.derived_id capnp "engine" in
+  let restore = Capnp_rpc_lwt.Restorer.single service_id (Rpc.engine engine) in
+  Logging.run begin
+    Capnp_rpc_unix.serve capnp ~restore >>= fun vat ->
+    let uri = Capnp_rpc_unix.Vat.sturdy_uri vat service_id in
+    let ch = open_out cap_file in
+    output_string ch (Uri.to_string uri ^ "\n");
+    close_out ch;
+    Logs.app (fun f -> f "Wrote capability reference to %S" cap_file);
+    Lwt.choose [
+      Current.Engine.thread engine;
+      Current_web.run ~mode engine;
+    ]
+  end
+
+(* Command-line parsing *)
+
+open Cmdliner
+
+let repo =
+  Arg.value @@
+  Arg.pos 0 Arg.dir (Sys.getcwd ()) @@
+  Arg.info
+    ~doc:"The directory containing the .git subdirectory."
+    ~docv:"DIR"
+    []
+
+let man = [
+  `S Manpage.s_options;
+  (* Update once https://github.com/mirage/capnp-rpc/pull/163 is merged: *)
+  (* `S "CAP'N PROTO OPTIONS"; *)
+]
+
+let cmd =
+  let doc = "A build server that can be controlled via Cap'n Proto RPC" in
+  Term.(const main $ Current.Config.cmdliner $ Current_web.cmdliner $ Capnp_rpc_unix.Vat_config.cmd $ repo),
+  Term.info "rpc_server" ~doc ~man
+
+let () = Term.(exit @@ eval cmd)

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -198,6 +198,8 @@ module Engine = struct
 
   let state t = !(t.last_result)
 
+  let jobs s = s.jobs
+
   let config t = t.config
 
   let thread t = t.thread

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -134,6 +134,8 @@ module Engine : sig
   val state : t -> results
   (** The most recent results from evaluating the pipeline. *)
 
+  val jobs : results -> actions Job_map.t
+
   val thread : t -> 'a Lwt.t
   (** [thread t] is the engine's thread.
       Use this to monitor the engine (in case it crashes). *)

--- a/lib_rpc/api.ml
+++ b/lib_rpc/api.ml
@@ -1,0 +1,1 @@
+include Schema.MakeRPC(Capnp_rpc_lwt)

--- a/lib_rpc/current_rpc.ml
+++ b/lib_rpc/current_rpc.ml
@@ -1,0 +1,3 @@
+module Engine = Engine
+module Job = Job
+module Impl = Impl.Make

--- a/lib_rpc/current_rpc.mli
+++ b/lib_rpc/current_rpc.mli
@@ -1,0 +1,43 @@
+module Job : sig
+  (** Client-side API to contact a job service. *)
+
+  type t = [`Job_8397ef9078537247] Capnp_rpc_lwt.Capability.t
+  type id = string
+
+  type status = {
+    id : id;
+    description : string;
+    can_cancel : bool;
+    can_rebuild : bool;
+  }
+
+  val log : t -> (string, [> `Capnp of Capnp_rpc.Error.t]) result Lwt.t
+  val cancel : t -> (unit, [> `Capnp of Capnp_rpc.Error.t]) result Lwt.t
+  val rebuild : t -> (unit, [> `Capnp of Capnp_rpc.Error.t]) result Lwt.t
+  val status : t -> (status, [> `Capnp of Capnp_rpc.Error.t]) result Lwt.t
+end
+
+module Engine : sig
+  (** Client-side API to contact an engine service. *)
+
+  type t = [`Engine_f0961466d2f9bbf5] Capnp_rpc_lwt.Capability.t
+
+  val active_jobs : t -> (Job.id list, [> `Capnp of Capnp_rpc.Error.t]) result Lwt.t
+  (** [active_jobs t] lists the OCurrent jobs that are still being used in the pipeline.
+      This includes completed jobs, as long as OCurrent is still ensuring they are up-to-date. *)
+
+  val job : t -> Job.id -> Job.t
+  (** [job t id] is the job with the given ID. This does not have to be an active job (but only
+      active jobs can be rebuilt). If the job ID is unknown, this operation will resolve to a
+      suitable error. *)
+end
+
+module Impl (Current : S.CURRENT) : sig
+  (** This is used on the server-side to provide access to the OCurrent Engine.
+      Create an instance of the functor with [module Rpc = Current_rpc.Impl(Current)].
+      We use a functor here just to avoid having Current_rpc depend on Current,
+      which would be annoying for RPC clients. *)
+
+  val engine : Current.Engine.t -> Engine.t
+  (** [engine e] is a Cap'n Proto engine service backed by [e]. *)
+end

--- a/lib_rpc/dune
+++ b/lib_rpc/dune
@@ -1,0 +1,10 @@
+(library
+  (public_name current_rpc)
+  (name current_rpc)
+  (libraries capnp-rpc-lwt lwt.unix fpath)
+  (flags (:standard -w -53-55)))
+
+(rule
+ (targets schema.ml schema.mli)
+ (deps schema.capnp)
+ (action (run capnpc -o ocaml %{deps})))

--- a/lib_rpc/engine.ml
+++ b/lib_rpc/engine.ml
@@ -1,0 +1,19 @@
+open Lwt.Infix
+open Capnp_rpc_lwt
+
+type t = Api.Service.Engine.t Capability.t
+
+module Engine = Api.Client.Engine
+
+let active_jobs t =
+  let open Engine.ActiveJobs in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_value t method_id request >|= function
+  | Error ex -> Error (`Capnp ex)
+  | Ok x -> Ok (Results.ids_get_list x)
+
+let job t id =
+  let open Engine.Job in
+  let request, params = Capability.Request.create Params.init_pointer in
+  Params.id_set params id;
+  Capability.call_for_caps t method_id request Results.job_get_pipelined

--- a/lib_rpc/impl.ml
+++ b/lib_rpc/impl.ml
@@ -1,0 +1,121 @@
+let read path =
+  let ch = open_in_bin (Fpath.to_string path) in
+  Fun.protect ~finally:(fun () -> close_in ch) @@ fun () ->
+  really_input_string ch (in_channel_length ch)
+
+module Make (Current : S.CURRENT) = struct
+  open Capnp_rpc_lwt
+
+  module Job = struct
+    let job_cache = ref Current.Job_map.empty
+
+    let local engine job_id =
+      let module Job = Api.Service.Job in
+      match Current.Job_map.find_opt job_id !job_cache with
+      | Some job ->
+        Capability.inc_ref job;
+        job
+      | None ->
+        let cap =
+          let lookup () =
+            let state = Current.Engine.state engine in
+            Current.Job_map.find_opt job_id (Current.Engine.jobs state)
+          in
+          Job.local @@ object
+            inherit Job.service
+
+            method log_impl _params release_param_caps =
+              let open Job.Log in
+              release_param_caps ();
+              Log.info (fun f -> f "log(%S)" job_id);
+              let response, results = Service.Response.create Results.init_pointer in
+              match Current.Job.log_path job_id with
+              | Error `Msg m -> Service.fail "%s" m
+              | Ok path ->
+                match read path with
+                | exception ex -> Service.fail "ERROR reading log: %a" Fmt.exn ex
+                | log ->
+                  Results.log_set results log;
+                  Service.return response
+
+            method rebuild_impl _params release_param_caps =
+              release_param_caps ();
+              Log.info (fun f -> f "rebuild(%S)" job_id);
+              match lookup () with
+              | None -> Service.fail "Job is no longer active (cannot rebuild)"
+              | Some job ->
+                match job#rebuild with
+                | None -> Service.fail "Job cannot be rebuilt at the moment"
+                | Some rebuild ->
+                  rebuild ();
+                  Service.return_empty ()
+
+            method cancel_impl _params release_param_caps =
+              release_param_caps ();
+              Log.info (fun f -> f "cancel(%S)" job_id);
+              match lookup () with
+              | None -> Service.fail "Job is no longer active (cannot cancel)"
+              | Some job ->
+                match job#cancel with
+                | None -> Service.fail "Job can no longer be cancelled"
+                | Some cancel ->
+                  cancel ();
+                  Service.return_empty ()
+
+            method status_impl _params release_param_caps =
+              let open Job.Status in
+              release_param_caps ();
+              Log.info (fun f -> f "status(%S)" job_id);
+              let response, results = Service.Response.create Results.init_pointer in
+              Results.id_set results job_id;
+              begin match lookup () with
+                | None -> Results.description_set results "Inactive job"
+                | Some job ->
+                  Results.description_set results (Fmt.strf "%t" job#pp);
+                  Results.can_cancel_set results (job#cancel <> None);
+                  Results.can_rebuild_set results (job#rebuild <> None);
+              end;
+              Service.return response
+
+            method! release =
+              job_cache := Current.Job_map.remove job_id !job_cache
+          end
+        in
+        job_cache := Current.Job_map.add job_id cap !job_cache;
+        cap
+
+    let local_opt engine job_id =
+      match Current.Job.log_path job_id with
+      | Error _ as e -> e
+      | Ok _ -> Ok (local engine job_id)
+  end
+
+  let engine engine =
+    let module Engine = Api.Service.Engine in
+    Engine.local @@ object
+      inherit Engine.service
+
+      method active_jobs_impl _params release_param_caps =
+        let open Engine.ActiveJobs in
+        release_param_caps ();
+        Log.info (fun f -> f "activeJobs");
+        let response, results = Service.Response.create Results.init_pointer in
+        let state = Current.Engine.state engine in
+        Current.Job_map.bindings (Current.Engine.jobs state)
+        |> List.map fst |> Results.ids_set_list results |> ignore;
+        Service.return response
+
+      method job_impl params release_param_caps =
+        let open Engine.Job in
+        let id = Params.id_get params in
+        Log.info (fun f -> f "job(%S)" id);
+        release_param_caps ();
+        let response, results = Service.Response.create Results.init_pointer in
+        match Job.local_opt engine id with
+        | Error `Msg m -> Service.fail "%s" m
+        | Ok job ->
+          Results.job_set results (Some job);
+          Capability.dec_ref job;
+          Service.return response
+    end
+end

--- a/lib_rpc/job.ml
+++ b/lib_rpc/job.ml
@@ -1,0 +1,49 @@
+open Lwt.Infix
+open Capnp_rpc_lwt
+
+type t = Api.Service.Job.t Capability.t
+
+type id = string
+
+type status = {
+  id : string;
+  description : string;
+  can_cancel : bool;
+  can_rebuild : bool;
+}
+
+module Job = Api.Client.Job
+
+let log t =
+  let open Job.Log in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_value t method_id request >|= function
+  | Ok x -> Ok (Results.log_get x)
+  | Error e -> Error (`Capnp e)
+
+let status t =
+  let open Job.Status in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_value t method_id request >|= function
+  | Error e -> Error (`Capnp e)
+  | Ok x ->
+    Ok {
+      id = Results.id_get x;
+      description = Results.description_get x;
+      can_cancel = Results.can_cancel_get x;
+      can_rebuild = Results.can_rebuild_get x;
+    }
+
+let cancel t =
+  let open Job.Cancel in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_unit t method_id request >|= function
+  | Error e -> Error (`Capnp e)
+  | Ok () -> Ok ()
+
+let rebuild t =
+  let open Job.Rebuild in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_unit t method_id request >|= function
+  | Error e -> Error (`Capnp e)
+  | Ok () -> Ok ()

--- a/lib_rpc/log.ml
+++ b/lib_rpc/log.ml
@@ -1,0 +1,2 @@
+let src = Logs.Src.create "current.rpc" ~doc:"OCurrent RPC"
+include (val Logs.src_log src : Logs.LOG)

--- a/lib_rpc/s.ml
+++ b/lib_rpc/s.ml
@@ -1,0 +1,27 @@
+(** The subset of the Current API that the RPC system needs.
+    This is duplicated here to avoid making RPC clients depend on
+    the "current" service implementation package. *)
+
+module type CURRENT = sig
+  module Job_map : Map.S with type key = string
+
+  class type actions = object
+    method pp : Format.formatter -> unit
+    method cancel : (unit -> unit) option
+    method rebuild : (unit -> unit) option
+    method release : unit
+  end
+
+  module Job : sig
+    type t
+    val log_path : string -> (Fpath.t, [`Msg of string]) result
+  end
+
+  module Engine : sig
+    type t
+    type results
+
+    val state : t -> results
+    val jobs : results -> actions Job_map.t
+  end
+end

--- a/lib_rpc/schema.capnp
+++ b/lib_rpc/schema.capnp
@@ -1,0 +1,20 @@
+@0xff960cc94b30cfb6;
+
+struct JobStatus {
+  id          @0 :Text;
+  description @1 :Text;
+  canCancel   @2 :Bool;
+  canRebuild  @3 :Bool;
+}
+
+interface Job {
+  status  @0 () -> JobStatus;
+  cancel  @1 () -> ();
+  rebuild @2 () -> ();
+  log     @3 () -> (log :Text);
+}
+
+interface Engine {
+  activeJobs @0 () -> (ids :List(Text));
+  job        @1 (id :Text) -> (job :Job);
+}


### PR DESCRIPTION
This allow interacting with the service via Cap'n Proto RPC. The examples directory contains an example server and client.

The operations currently supported are:

- List active jobs.
- Get the status of a job.
- Fetch a job's log (not streaming yet).
- Cancel a job.
- Rebuild a job.

This also adds a `current_examples` opam package to ensure that the examples are built and tested too. It also removes the `.log` suffix from job IDs, to avoid confusion.