### PR TITLE
Follow log files with rpc_client

### DIFF
--- a/examples/rpc_client.ml
+++ b/examples/rpc_client.ml
@@ -70,7 +70,7 @@ let cancel job =
 let rebuild job =
   Fmt.pr "Requesting rebuild...@.";
   let new_job = Current_rpc.Job.rebuild job in
-  show_status new_job
+  show_log new_job
 
 let main ?job_id ~job_op engine_url =
   let vat = Capnp_rpc_unix.client_only_vat () in

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -4,7 +4,7 @@ type 'a or_error = ('a, [`Msg of string]) result
 
 module Config = Config
 
-module Job_map = Map.Make(String)
+module Job_map = Job.Map
 
 module Metrics = struct
   open Prometheus

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -266,6 +266,16 @@ module Job : sig
 
   val pp_id : job_id Fmt.t
 
+  val is_running : t -> bool
+  (** [is_running t] is true if the log file is still open. *)
+
+  val wait_for_log_data : t -> unit Lwt.t
+  (** [wait_for_log_data t] is a promise that resolves the next time log data
+      is written or the log is closed. *)
+
+  val lookup_running : job_id -> t option
+  (** If [lookup_running job_id] is the job [j] with id [job_id], if [is_running j]. *)
+
   (**/**)
 
   (* For unit tests we need our own test clock: *)

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -264,8 +264,6 @@ module Job : sig
   val log_path : job_id -> Fpath.t or_error
   (** [log_path id] is the path of the log for job [id], if valid. *)
 
-  val fd : t -> Unix.file_descr
-
   val pp_id : job_id Fmt.t
 
   (**/**)

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -34,11 +34,6 @@ let log t fmt =
 
 let id t = t.id
 
-let fd t =
-  match t.ch with
-  | None -> Fmt.failwith "Job.fd(%s) called on closed job" t.id
-  | Some ch -> Unix.descr_of_out_channel ch
-
 let jobs_dir = lazy (Disk_store.state_dir "job")
 
 let log_path job_id =

--- a/lib_rpc/s.ml
+++ b/lib_rpc/s.ml
@@ -15,6 +15,8 @@ module type CURRENT = sig
   module Job : sig
     type t
     val log_path : string -> (Fpath.t, [`Msg of string]) result
+    val lookup_running : string -> t option
+    val wait_for_log_data : t -> unit Lwt.t
   end
 
   module Engine : sig

--- a/lib_rpc/schema.capnp
+++ b/lib_rpc/schema.capnp
@@ -16,6 +16,8 @@ interface Job {
   # Return a chunk of log data starting at byte offset "start" and the
   # value to use for "start" in the next call to continue reading.
   # Returns 0 bytes of data to indicate end-of-file.
+  # If the log is incomplete and there is no data currently available,
+  # it waits until something changes before returning.
   # If "start" is negative then it is relative to the end of the log.
 }
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -125,4 +125,5 @@ let () =
     ];
     "cache", Test_cache.tests;
     "monitor", Test_monitor.tests;
+    "job", Test_job.tests;
   ]

--- a/test/test_job.ml
+++ b/test/test_job.ml
@@ -1,0 +1,70 @@
+open Lwt.Infix
+
+module Job = Current.Job
+
+let read path =
+  let ch = open_in_bin (Fpath.to_string path) in
+  let data = really_input_string ch (in_channel_length ch) in
+  close_in ch;
+  data
+
+let ( >>!= ) x f =
+  x >>= function
+  | Ok y -> f y
+  | Error `Msg m -> failwith m
+
+let streams _switch () =
+  Job.timestamp := (fun () -> 0.0);
+  let switch = Current.Switch.create ~label:"streams" () in
+  let config = Current.Config.v () in
+  let job = Job.create ~switch ~label:"streams" ~config () in
+  let log_data = Job.wait_for_log_data job in
+  assert (Lwt.state log_data = Lwt.Sleep);
+  let cmd = ("", [| "sh"; "-c"; "echo out1; echo >&2 out2; echo out3" |]) in
+  Current.Process.exec ~switch ~job cmd >>!= fun () ->
+  Current.Switch.turn_off switch @@ Ok () >>= fun () ->
+  assert (Lwt.state log_data != Lwt.Sleep);
+  let path = Job.log_path (Job.id job) |> Stdlib.Result.get_ok in
+  Alcotest.(check string) "Combined results" "1970-01-01 00:00.00: Exec: \"sh\" \"-c\" \"echo out1; echo >&2 out2; echo out3\"\n\
+                                              out1\nout2\nout3\n" (read path);
+  Lwt.return_unit
+
+let output _switch () =
+  Job.timestamp := (fun () -> 0.0);
+  let switch = Current.Switch.create ~label:"output" () in
+  let config = Current.Config.v () in
+  let job = Job.create ~switch ~label:"output" ~config () in
+  let cmd = ("", [| "sh"; "-c"; "echo out1; echo >&2 out2; echo out3" |]) in
+  Current.Process.check_output ~switch ~job cmd >>!= fun out ->
+  Current.Switch.turn_off switch @@ Ok () >>= fun () ->
+  Alcotest.(check string) "Output" "out1\nout3\n" out;
+  let path = Job.log_path (Job.id job) |> Stdlib.Result.get_ok in
+  Alcotest.(check string) "Log" "1970-01-01 00:00.00: Exec: \"sh\" \"-c\" \"echo out1; echo >&2 out2; echo out3\"\n\
+                                 out2\n" (read path);
+  Lwt.return_unit
+
+let cancel _switch () =
+  Job.timestamp := (fun () -> 0.0);
+  let switch = Current.Switch.create ~label:"cancel" () in
+  let config = Current.Config.v () in
+  let job = Job.create ~switch ~label:"output" ~config () in
+  let cmd = ("", [| "sleep"; "120" |]) in
+  let thread = Current.Process.exec ~switch ~job cmd in
+  Current.Switch.turn_off switch @@ Error (`Msg "Timeout") >>= fun () ->
+  thread >>= fun res ->
+  begin match res with
+    | Ok () -> Alcotest.fail "Should have failed!"
+    | Error `Msg m when Astring.String.is_prefix ~affix:"Command \"sleep\" \"120\" failed with signal" m -> ()
+    | Error `Msg m -> Alcotest.failf "Expected signal error, not %S" m
+  end;
+  let path = Job.log_path (Job.id job) |> Stdlib.Result.get_ok in
+  Alcotest.(check string) "Log" "1970-01-01 00:00.00: Exec: \"sleep\" \"120\"\n\
+                                 1970-01-01 00:00.00: Timeout\n" (read path);
+  Lwt.return_unit
+
+let tests =
+  [
+    Alcotest_lwt.test_case "streams" `Quick streams;
+    Alcotest_lwt.test_case "output" `Quick output;
+    Alcotest_lwt.test_case "cancel" `Quick cancel;
+  ]

--- a/test/test_job.mli
+++ b/test/test_job.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list


### PR DESCRIPTION
 When asking for log data and there isn't any more but the job is still running, the server now waits for more data and retries. This allows the RPC client to follow the log files.

Triggering a rebuild from the client now also follows the new job's log.