### PR TITLE
Add Analysis.job_id

### DIFF
--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -298,4 +298,9 @@ module Make (Job : sig type id end) = struct
   let booting =
     let env = make_env () in
     active ~env `Running
+
+  let job_id t =
+    match t.ty with
+    | Bind_input i -> i.id
+    | _ -> None
 end

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -38,6 +38,8 @@ module Make (Job : sig type id end) : sig
 
   val set_state : t -> ?id:Job.id -> state -> unit
 
+  val job_id : t -> Job.id option
+
   val pp : t Fmt.t
   val pp_dot : url:(Job.id -> string option) -> t Fmt.t
 end

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -34,6 +34,9 @@ module type ANALYSIS = sig
 
   val get : _ term -> t term
 
+  val job_id : t -> job_id option
+  (** [job_id t] is the job ID of [t], if any. *)
+
   val pp : t Fmt.t
   (** [pp] formats a [t] as a simple string. *)
 


### PR DESCRIPTION
This is useful to allow indexing jobs. For example, ocaml-ci can use this to get the job ID of each Docker build and record a mapping from commit hashes to build logs.