### PR TITLE
Allow labelling of 'docker run' stages

### DIFF
--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -38,8 +38,8 @@ module Make (Host : S.HOST) = struct
 
   module RC = Current_cache.Make(Run)
 
-  let run image ~args =
-    Current.component "run" |>
+  let run ?label image ~args =
+    Current.component "run%a" pp_sp_label label |>
     let> image = image in
     RC.get Run.No_context { Run.Key.image; args; docker_context }
 

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -36,7 +36,7 @@ module type DOCKER = sig
       @param pull If [true], always check for updates and pull the latest version.
       @param pool Rate limit builds by requiring a resource from the pool. *)
 
-  val run : Image.t Current.t -> args:string list -> unit Current.t
+  val run : ?label:string -> Image.t Current.t -> args:string list -> unit Current.t
   (** [run image ~args] runs [image args] with Docker. *)
 
   val tag : tag:string -> Image.t Current.t -> unit Current.t


### PR DESCRIPTION
This matches the API of the 'build' and 'pull' stages