### PR TITLE
Remove .git extension when showing git clone command

### DIFF
--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -79,7 +79,7 @@ let with_checkout ~switch ~job commit fn =
     short_hash
     id.Commit_id.repo
     (strip_heads id.Commit_id.gref)
-    (Filename.basename id.Commit_id.repo)
+    (Filename.basename id.Commit_id.repo |> Filename.chop_extension)
     short_hash;
   Current.Process.with_tmpdir ~prefix:"git-checkout" @@ fun tmpdir ->
   Cmd.cp_r ~switch ~job ~src:(Fpath.(repo / ".git")) ~dst:tmpdir >>!= fun () ->


### PR DESCRIPTION
After cloning `foo.git`, it told you to `cd foo.git`.