### PR TITLE
Improvements to job confirmation

### DIFF
--- a/examples/github_app.ml
+++ b/examples/github_app.ml
@@ -9,7 +9,7 @@ module Github = Current_github
 module Docker = Current_docker.Default
 
 (* Limit to one build at a time. *)
-let pool = Lwt_pool.create 1 Lwt.return
+let pool = Current.Pool.create ~label:"docker" 1
 
 let () = Logging.init ()
 

--- a/examples/rpc_client.ml
+++ b/examples/rpc_client.ml
@@ -67,6 +67,13 @@ let cancel job =
   Current_rpc.Job.cancel job |> Lwt_result.map @@ fun () ->
   Fmt.pr "Cancelled@."
 
+let start job =
+  Current_rpc.Job.approve_early_start job >>= function
+  | Error _ as e -> Lwt.return e
+  | Ok () ->
+    Fmt.pr "Job is now approved to start without waiting for confirmation.@.";
+    show_log job
+
 let rebuild job =
   Fmt.pr "Requesting rebuild...@.";
   let new_job = Current_rpc.Job.rebuild job in
@@ -116,11 +123,12 @@ let job_op =
     "status", `Show_status;
     "cancel", `Cancel;
     "rebuild", `Rebuild;
+    "start", `Start;
   ] in
   Arg.value @@
   Arg.pos 2 Arg.(enum ops) `Show_status @@
   Arg.info
-    ~doc:"The operation to perform (log, status, cancel or rebuild)."
+    ~doc:"The operation to perform (log, status, cancel, rebuild or start)."
     ~docv:"METHOD"
     []
 
@@ -130,6 +138,7 @@ let to_fn = function
   | `Rebuild -> rebuild
   | `Show_log -> show_log
   | `Show_status -> show_status
+  | `Start -> start
 
 let cmd =
   let doc = "Client for rpc_server.ml" in

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -330,3 +330,4 @@ module Db = Db
 module Job = Job
 module Process = Process
 module Switch = Switch
+module Pool = Pool

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -235,6 +235,15 @@ module Switch : sig
   (** Prints the state of the switch (for debugging). *)
 end
 
+module Pool : sig
+  type t
+  (** A pool of resources, to control how many jobs can use a resource at a time. *)
+
+  val create : label:string -> int -> t
+  (** [create ~label n] is a pool with [n] resources.
+      @param label Used for metric reporting and logging. *)
+end
+
 module Job : sig
   type t
 
@@ -243,10 +252,12 @@ module Job : sig
       @param switch Turning this off will cancel the job.
       @param label A label to use in the job's filename (for debugging). *)
 
-  val start : ?timeout:Duration.t -> level:Level.t -> t -> unit Lwt.t
+  val start : ?timeout:Duration.t -> ?pool:Pool.t -> level:Level.t -> t -> unit Lwt.t
   (** [start t ~level] marks [t] as running. This can only be called once per job.
       If confirmation has been configured for [level], then this will wait for confirmation first.
-      @param timeout If given, the job will be cancelled automatically after this period of time. *)
+      @param timeout If given, the job will be cancelled automatically after this period of time.
+      @param pool If given, the job cannot start until a pool resource is available.
+                  The resource is freed when the job finishes. *)
 
   val start_time : t -> float Lwt.t
   (** [start_time t] is the time when [start] was called, or an

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -276,6 +276,11 @@ module Job : sig
   val lookup_running : job_id -> t option
   (** If [lookup_running job_id] is the job [j] with id [job_id], if [is_running j]. *)
 
+  val approve_early_start : t -> unit
+  (** [approve_early_start t] marks the job as approved to start even if the
+      global confirmation threshold would otherwise prevent it. Calling this
+      more than once has no effect. *)
+
   (**/**)
 
   (* For unit tests we need our own test clock: *)

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -107,25 +107,38 @@ let pp_id = Fmt.string
 
 let is_running t = Lwt.state t.start_time <> Lwt.Sleep
 
-let confirm t level =
-  let confirmed = Config.confirmed level t.config in
-  Switch.add_hook_or_fail t.switch (fun _ -> Lwt.cancel confirmed; Lwt.return_unit);
-  match Lwt.state confirmed with
-  | Lwt.Return () -> Lwt.return_unit
-  | _ ->
-    log t "Waiting for confirm-threshold > %a" Level.pp level;
-    Log.info (fun f -> f "Waiting for confirm-threshold > %a" Level.pp level);
-    Lwt.choose [confirmed; t.explicit_confirm] >|= fun () ->
-    if Lwt.state confirmed <> Lwt.Sleep then (
-      log t "Confirm-threshold now > %a" Level.pp level;
-      Log.info (fun f -> f "Confirm-threshold now > %a" Level.pp level)
-    );
-    if Lwt.state t.explicit_confirm <> Lwt.Sleep then (
-      log t "Explicit approval received for this job"
-    )
+let confirm t ?pool level =
+  let confirmed =
+    let confirmed = Config.confirmed level t.config in
+    Switch.add_hook_or_fail t.switch (fun _ -> Lwt.cancel confirmed; Lwt.return_unit);
+    match Lwt.state confirmed with
+    | Lwt.Return () -> Lwt.return_unit
+    | _ ->
+      log t "Waiting for confirm-threshold > %a" Level.pp level;
+      Log.info (fun f -> f "Waiting for confirm-threshold > %a" Level.pp level);
+      Lwt.choose [confirmed; t.explicit_confirm] >>= fun () ->
+      if Lwt.state confirmed <> Lwt.Sleep then (
+        log t "Confirm-threshold now > %a" Level.pp level;
+        Log.info (fun f -> f "Confirm-threshold now > %a" Level.pp level)
+      );
+      if Lwt.state t.explicit_confirm <> Lwt.Sleep then (
+        log t "Explicit approval received for this job"
+      );
+      Lwt.return_unit
+  in
+  confirmed >>= fun () ->
+  match pool with
+  | None -> Lwt.return_unit
+  | Some pool ->
+    let res = Pool.get ~switch:t.switch pool in
+    if Lwt.is_sleeping res then (
+      log t "Waiting for resource in pool %a" Pool.pp pool;
+      res >|= fun () ->
+      log t "Got resource from pool %a" Pool.pp pool
+    ) else res
 
-let start ?timeout ~level t =
-  confirm t level >|= fun () ->
+let start ?timeout ?pool ~level t =
+  confirm t ?pool level >|= fun () ->
   if is_running t then (
     Log.warn (fun f -> f "start called, but job %s is already running!" t.id);
     Fmt.failwith "Job.start called twice!"

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -14,6 +14,8 @@ type t = {
   start_time : float Lwt.t;
   mutable ch : out_channel option;
   log_cond : unit Lwt_condition.t;  (* Fires whenever log data is written, or log is closed. *)
+  explicit_confirm : unit Lwt.t;
+  set_explicit_confirm : unit Lwt.u; (* Resolve this to override the global confirmation threshold. *)
 }
 
 let jobs = ref Map.empty
@@ -83,7 +85,9 @@ let create ~switch ~label ~config () =
     let id = id_of_path path in
     let start_time, set_start_time = Lwt.wait () in
     let log_cond = Lwt_condition.create () in
-    let t = { switch; id; ch = Some ch; start_time; set_start_time; config; log_cond } in
+    let explicit_confirm, set_explicit_confirm = Lwt.wait () in
+    let t = { switch; id; ch = Some ch; start_time; set_start_time; config; log_cond;
+              explicit_confirm; set_explicit_confirm } in
     jobs := Map.add id t !jobs;
     Switch.add_hook_or_fail switch (fun reason ->
         begin match reason with
@@ -111,9 +115,14 @@ let confirm t level =
   | _ ->
     log t "Waiting for confirm-threshold > %a" Level.pp level;
     Log.info (fun f -> f "Waiting for confirm-threshold > %a" Level.pp level);
-    confirmed >|= fun () ->
-    log t "Confirm-threshold now > %a" Level.pp level;
-    Log.info (fun f -> f "Confirm-threshold now > %a" Level.pp level)
+    Lwt.choose [confirmed; t.explicit_confirm] >|= fun () ->
+    if Lwt.state confirmed <> Lwt.Sleep then (
+      log t "Confirm-threshold now > %a" Level.pp level;
+      Log.info (fun f -> f "Confirm-threshold now > %a" Level.pp level)
+    );
+    if Lwt.state t.explicit_confirm <> Lwt.Sleep then (
+      log t "Explicit approval received for this job"
+    )
 
 let start ?timeout ~level t =
   confirm t level >|= fun () ->
@@ -129,3 +138,9 @@ let start_time t = t.start_time
 let wait_for_log_data t = Lwt_condition.wait t.log_cond
 
 let lookup_running id = Map.find_opt id !jobs
+
+let approve_early_start t =
+  match Lwt.state t.explicit_confirm with
+  | Lwt.Sleep -> Lwt.wakeup t.set_explicit_confirm ()
+  | Lwt.Return () -> ()
+  | Lwt.Fail ex -> raise ex

--- a/lib/pool.ml
+++ b/lib/pool.ml
@@ -1,0 +1,60 @@
+open Lwt.Infix
+
+module Metrics = struct
+  open Prometheus
+
+  let namespace = "ocurrent"
+  let subsystem = "pool"
+
+  let qlen =
+    let help = "Number of users waiting for a resource" in
+    Gauge.v_label ~help ~label_name:"name" ~namespace ~subsystem "qlen"
+
+  let resources_in_use =
+    let help = "Number of resources currently being used" in
+    Gauge.v_label ~help ~label_name:"name" ~namespace ~subsystem
+      "resources_in_use"
+
+  let capacity =
+    let help = "Total pool capacity" in
+    Gauge.v_label ~help ~label_name:"name" ~namespace ~subsystem "capacity"
+end
+
+type t = {
+  label : string;
+  mutable used : int;
+  capacity : int;
+  cond : unit Lwt_condition.t;
+}
+
+let create ~label capacity =
+  Prometheus.Gauge.set (Metrics.capacity label) (float_of_int capacity);
+  { label; used = 0; capacity; cond = Lwt_condition.create () }
+
+let get ~switch t =
+  let rec aux () =
+    if t.used < t.capacity then (
+      if Switch.is_on switch then (
+        Prometheus.Gauge.inc_one (Metrics.resources_in_use t.label);
+        t.used <- t.used + 1;
+        Switch.add_hook_or_exec switch (fun _reason ->
+            assert (t.used > 0);
+            Prometheus.Gauge.dec_one (Metrics.resources_in_use t.label);
+            t.used <- t.used - 1;
+            Lwt_condition.broadcast t.cond ();
+            Lwt.return_unit
+          )
+      ) else Fmt.failwith "Cancelled waiting for resource from pool %S" t.label
+    ) else (
+      Prometheus.Gauge.inc_one (Metrics.qlen t.label);
+      Lwt_condition.wait t.cond >>= fun () ->
+      Prometheus.Gauge.dec_one (Metrics.qlen t.label);
+      aux ()
+    )
+  in
+  let res = aux () in
+  Switch.add_hook_or_exec switch (fun _ex -> Lwt.cancel res; Lwt.return_unit) >>= fun () ->
+  res
+
+let pp f t =
+  Fmt.string f t.label

--- a/lib/pool.mli
+++ b/lib/pool.mli
@@ -1,0 +1,9 @@
+type t
+
+val create : label:string -> int -> t
+
+val get : switch:Switch.t -> t -> unit Lwt.t
+(** [get ~switch t] waits for a resource and then returns.
+    The resource will be returned to the pool when [switch] is turned off. *)
+
+val pp : t Fmt.t

--- a/lib_rpc/current_rpc.mli
+++ b/lib_rpc/current_rpc.mli
@@ -19,6 +19,10 @@ module Job : sig
 
   val rebuild : t -> t
   (** [rebuild t] requests a rebuild of [t] and returns the new job. *)
+
+  val approve_early_start : t -> (unit, [> `Capnp of Capnp_rpc.Error.t]) result Lwt.t
+  (* Mark the job as approved to start even if the global confirmation threshold
+     would otherwise prevent it. Calling this more than once has no effect. *)
 end
 
 module Engine : sig

--- a/lib_rpc/impl.ml
+++ b/lib_rpc/impl.ml
@@ -112,6 +112,16 @@ module Make (Current : S.CURRENT) = struct
               end;
               Service.return response
 
+            method approve_early_start_impl _params release_param_caps =
+              release_param_caps ();
+              Log.info (fun f -> f "approveEarlyStart(%S)" job_id);
+              match Current.Job.lookup_running job_id with
+              | None -> Service.fail "Job is not running (cannot approve early start)"
+              | Some job ->
+                let response = Service.Response.create_empty () in
+                Current.Job.approve_early_start job;
+                Service.return response
+
             method! release =
               job_cache := Current.Job_map.remove job_id !job_cache
           end

--- a/lib_rpc/job.ml
+++ b/lib_rpc/job.ml
@@ -46,3 +46,10 @@ let rebuild t =
   let open Job.Rebuild in
   let request = Capability.Request.create_no_args () in
   Capability.call_for_caps t method_id request Results.job_get_pipelined
+
+let approve_early_start t =
+  let open Job.ApproveEarlyStart in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_unit t method_id request >|= function
+  | Error e -> Error (`Capnp e)
+  | Ok () -> Ok ()

--- a/lib_rpc/s.ml
+++ b/lib_rpc/s.ml
@@ -17,6 +17,7 @@ module type CURRENT = sig
     val log_path : string -> (Fpath.t, [`Msg of string]) result
     val lookup_running : string -> t option
     val wait_for_log_data : t -> unit Lwt.t
+    val approve_early_start : t -> unit
   end
 
   module Engine : sig

--- a/lib_rpc/schema.capnp
+++ b/lib_rpc/schema.capnp
@@ -19,6 +19,10 @@ interface Job {
   # If the log is incomplete and there is no data currently available,
   # it waits until something changes before returning.
   # If "start" is negative then it is relative to the end of the log.
+
+  approveEarlyStart @4 () -> ();
+  # Mark the job as approved to start even if the global confirmation threshold
+  # would otherwise prevent it. Calling this more than once has no effect.
 }
 
 interface Engine {

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 type t = {
   pull : bool;
-  pool : unit Lwt_pool.t option;
+  pool : Current.Pool.t option;
   timeout : Duration.t option;
 }
 
@@ -63,8 +63,7 @@ let build ~switch { pull; pool; timeout } job key =
   dockerfile |> Option.iter (fun contents ->
       Current.Job.log job "@[<v2>Using Dockerfile:@,%a@]" Fmt.lines contents
     );
-  use_pool pool @@ fun () ->
-  Current.Job.start ?timeout job ~level:Current.Level.Average >>= fun () ->
+  Current.Job.start ?timeout ?pool job ~level:Current.Level.Average >>= fun () ->
   with_context ~switch ~job commit @@ fun dir ->
   dockerfile |> Option.iter (fun contents ->
       Bos.OS.File.write Fpath.(dir / "Dockerfile") (contents ^ "\n") |> or_raise;

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -25,7 +25,7 @@ module type DOCKER = sig
     ?squash:bool ->
     ?label:string ->
     ?dockerfile:Dockerfile.t Current.t ->
-    ?pool:unit Lwt_pool.t ->
+    ?pool:Current.Pool.t ->
     pull:bool ->
     source ->
     Image.t Current.t

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -436,7 +436,7 @@ module Commit = struct
 
     module Outcome = Current.Unit
 
-    let auto_cancel = false
+    let auto_cancel = true
 
     let pp f ({ Key.commit; context }, status) =
       Fmt.pf f "Set %a/%s to %a"


### PR DESCRIPTION
- Add approve-early-start operation to skip job confirmation
- Allow auto-cancelling GitHub set-status, so that if a job's state is only "pending" while pushing status updates was disabled, we don't push this status once updating is enabled.
- Wait for confirmation before getting pool resources, so that approving a single job doesn't get blocked by other non-approved jobs.