### PR TITLE
[github] Add Api.Repo module

### DIFF
--- a/examples/github_app.ml
+++ b/examples/github_app.ml
@@ -39,10 +39,9 @@ let pipeline ~app () =
     dockerfile ~base
   in
   Github.App.installations app |> Current.list_iter ~pp:Github.Installation.pp @@ fun installation ->
-  let github = Current.map Github.Installation.api installation in
   let repos = Github.Installation.repositories installation in
-  repos |> Current.list_iter ~pp:Github.Repo_id.pp @@ fun repo ->
-  Github.Api.ci_refs_dyn github repo
+  repos |> Current.list_iter ~pp:Github.Api.Repo.pp @@ fun repo ->
+  Github.Api.Repo.ci_refs repo
   |> Current.list_iter ~pp:Github.Api.Commit.pp @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   Docker.build ~pool ~pull:false ~dockerfile (`Git src)

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -20,10 +20,17 @@ type t
 val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
-val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t Current.t
 val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
-val ci_refs_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t
+
+module Repo : sig
+  type nonrec t = t * Repo_id.t
+
+  val id : t -> Repo_id.t
+  val ci_refs : t Current.t -> Commit.t list Current.t
+  val head_commit : t Current.t -> Commit.t Current.t
+  val pp : t Fmt.t
+end
 
 (* Private API *)
 

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -49,6 +49,19 @@ module Api : sig
     val pp : t Fmt.t
   end
 
+  module Repo : sig
+    type nonrec t = t * Repo_id.t
+
+    val id : t -> Repo_id.t
+    val pp : t Fmt.t
+
+    val ci_refs : t Current.t -> Commit.t list Current.t
+    (** [ci_refs t] evaluates to the list of branches and open PRs in [t]. *)
+
+    val head_commit : t Current.t -> Commit.t Current.t
+    (** [head_commit t] evaluates to the commit at the head of the default branch in [t]. *)
+  end
+
   val of_oauth : string -> t
   (** [of_oauth token] is a configuration that authenticates to GitHub using [token]. *)
 
@@ -58,14 +71,8 @@ module Api : sig
   val head_commit : t -> Repo_id.t -> Commit.t Current.t
   (** [head_commit t repo] evaluates to the commit at the head of the default branch in [repo]. *)
 
-  val head_commit_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t Current.t
-  (** Like [head_commit], but the inputs are both currents. *)
-
   val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
   (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo]. *)
-
-  val ci_refs_dyn : t Current.t -> Repo_id.t Current.t -> Commit.t list Current.t
-  (** Like [ci_refs], but the inputs are both currents. *)
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub configuration. *)
@@ -81,7 +88,7 @@ module Installation : sig
   val pp : t Fmt.t
   (** The GitHub account that installed the app. *)
 
-  val repositories : t Current.t -> Repo_id.t list Current.t
+  val repositories : t Current.t -> Api.Repo.t list Current.t
   (** [repositories t] evaluates to the list of repositories which the user
       configured for this installation. *)
 end

--- a/plugins/github/installation.mli
+++ b/plugins/github/installation.mli
@@ -3,7 +3,8 @@
 type t
 val api : t -> Api.t
 val pp : t Fmt.t
-val repositories : t Current.t -> Repo_id.t list Current.t
+
+val repositories : t Current.t -> Api.Repo.t list Current.t
 
 (* Private API *)
 


### PR DESCRIPTION
This cleans up the graph a bit, since you no longer need to combine an `Api.t` with a `Repo_id.t`.