### PR TITLE
Constrain capnp-rpc-unix version in examples

### DIFF
--- a/current_examples.opam
+++ b/current_examples.opam
@@ -21,6 +21,6 @@ depends: [
   "current_github" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.3.3"}
+  "capnp-rpc-unix" {>= "0.3.3" & < "0.5"}
   "dune"
 ]


### PR DESCRIPTION
This will need updating slightly once 0.5 is out, due to https://github.com/mirage/capnp-rpc/pull/182