### PR TITLE
Add missing test dependencies to current_rpc

### DIFF
--- a/current_rpc.opam
+++ b/current_rpc.opam
@@ -54,6 +54,8 @@ depends: [
   "prometheus-app" {>= "1.2"}
   "result" {>= "1.5"}
   "stdint" {>= "0.7.0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/dune-project
+++ b/dune-project
@@ -265,7 +265,9 @@ an OCurrent engine to be controlled remotely.")
   (lwt (>= 5.7))
   (prometheus-app (>= 1.2))
   (result (>= 1.5))
-  (stdint (>= 0.7.0)))
+  (stdint (>= 0.7.0))
+  (alcotest :with-test)
+  (alcotest-lwt :with-test))
  (conflicts
   (x509 (= 0.11.0))))
 


### PR DESCRIPTION
Add `alcotest` and `alcotest-lwt` as `{with-test}` dependencies to `current_rpc`. These are required by `lib_rpc/test` but were missing, causing opam-repo-ci failures.