### PR TITLE
docker: add ?os to Peek and Pull (default linux)

### DIFF
--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -134,8 +134,7 @@ module Make (Host : S.HOST) = struct
 
   let peek ?label ~arch ?(os="linux") ~schedule tag =
     let label = Option.value label ~default:tag in
-    let os_label = if os = "linux" then "" else "@," ^ os in
-    Current.component "peek %s@,%s%s" label arch os_label |>
+    Current.component "peek %s@,%s@,%s" label arch os |>
     let> () = Current.return () in
     Raw.peek ~docker_context ~schedule ~arch ~os tag
 

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -9,13 +9,13 @@ module Raw = struct
 
   module PullC = Current_cache.Make(Pull)
 
-  let pull ~docker_context ~schedule ?auth ?server ?arch tag =
-    PullC.get ~schedule (Auth.v ~auth ~server) { Pull.Key.docker_context; tag; arch }
+  let pull ~docker_context ~schedule ?auth ?server ?arch ?os tag =
+    PullC.get ~schedule (Auth.v ~auth ~server) { Pull.Key.docker_context; tag; arch; os }
 
   module PeekC = Current_cache.Make(Peek)
 
-  let peek ~docker_context ~schedule ~arch tag =
-    PeekC.get ~schedule Peek.No_context { Peek.Key.docker_context; tag; arch }
+  let peek ~docker_context ~schedule ~arch ?(os="linux") tag =
+    PeekC.get ~schedule Peek.No_context { Peek.Key.docker_context; tag; arch; os }
 
   module BC = Current_cache.Make(Build)
 
@@ -132,11 +132,12 @@ module Make (Host : S.HOST) = struct
     let> () = Current.return () in
     Raw.pull ~docker_context ~schedule ?arch ?auth ?server tag
 
-  let peek ?label ~arch ~schedule tag =
+  let peek ?label ~arch ?(os="linux") ~schedule tag =
     let label = Option.value label ~default:tag in
-    Current.component "peek %s@,%s" label arch |>
+    let os_label = if os = "linux" then "" else "@," ^ os in
+    Current.component "peek %s@,%s%s" label arch os_label |>
     let> () = Current.return () in
-    Raw.peek ~docker_context ~schedule ~arch tag
+    Raw.peek ~docker_context ~schedule ~arch ~os tag
 
   let pp_sp_label = Fmt.(option (sp ++ string))
 

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -26,12 +26,13 @@ module Raw : sig
     schedule:Current_cache.Schedule.t ->
     ?auth:(string * string) ->
     ?server:string ->
-    ?arch:string -> string -> Image.t Current.Primitive.t
+    ?arch:string -> ?os:string -> string -> Image.t Current.Primitive.t
 
   val peek :
     docker_context:string option ->
     schedule:Current_cache.Schedule.t ->
-    arch:string -> string -> S.repo_id Current.Primitive.t
+    arch:string -> ?os:string -> string -> S.repo_id Current.Primitive.t
+  (** [os] defaults to ["linux"]. *)
 
   val build :
     docker_context:string option ->

--- a/plugins/docker/peek.ml
+++ b/plugins/docker/peek.ml
@@ -8,6 +8,7 @@ module Key = struct
   type t = {
     docker_context : string option;
     arch: string;
+    os: string;
     tag : string;
   } [@@deriving to_yojson]
 
@@ -22,10 +23,10 @@ let id = "docker-peek"
 
 let build No_context job key =
   Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
-  let { Key.docker_context = _; tag; arch } = key in
+  let { Key.docker_context = _; tag; arch; os } = key in
   Prometheus.Gauge.inc_one Metrics.docker_peek_events;
   Current.Process.check_output ~cancellable:true ~job (Key.cmd key) >>!= (fun manifest ->
-    match Pull.get_digest_from_manifest manifest arch with
+    match Pull.get_digest_from_manifest manifest ~arch ~os with
     | Error _ as e -> Lwt.return e
     | Ok hash ->
       Current.Job.log job "Got %S" hash;

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -12,6 +12,7 @@ module Key = struct
   type t = {
     docker_context : string option;
     arch: string option;
+    os: string option;
     tag : string;
   } [@@deriving to_yojson]
 
@@ -22,7 +23,7 @@ end
 
 module Value = Image
 
-let get_digest_from_manifest manifest arch =
+let get_digest_from_manifest manifest ~arch ~os =
   let open Yojson.Basic.Util in
   match Yojson.Basic.from_string manifest with
   | exception ex -> Fmt.error_msg "Failed to parse manifest JSON: %a@\n%S" Fmt.exn ex manifest
@@ -31,17 +32,17 @@ let get_digest_from_manifest manifest arch =
       json |> member "manifests" |> to_list |>
       List.find (fun j -> member "platform" j |> fun j ->
                           (member "architecture" j |> to_string = arch) &&
-                          (member "os" j |> to_string = "linux")) |>
+                          (member "os" j |> to_string = os)) |>
       member "digest" |> fun digest -> Ok (to_string digest)
     with ex ->
-      Fmt.error_msg "Failed to find arch %S in manifest (%a):@,%a"
-        arch
+      Fmt.error_msg "Failed to find arch %S os %S in manifest (%a):@,%a"
+        arch os
         Fmt.exn ex
         (Yojson.Basic.pretty_print ~std:true) json
 
 let build auth job key =
   Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
-  let { Key.docker_context; tag; arch } = key in
+  let { Key.docker_context; tag; arch; os } = key in
   Auth.login ~docker_context ~job auth >>!= (fun () ->
   Prometheus.Gauge.inc_one Metrics.docker_pull_events;
   match arch with
@@ -56,7 +57,8 @@ let build auth job key =
   | Some arch -> begin
       let cmd = Cmd.docker ~docker_context ["manifest"; "inspect"; tag ] in
       Current.Process.check_output ~cancellable:true ~job cmd >>!= fun manifest ->
-      match get_digest_from_manifest manifest arch with
+      let os = Option.value os ~default:"linux" in
+      match get_digest_from_manifest manifest ~arch ~os with
       | Error _ as e -> Lwt.return e
       | Ok hash ->
         let full_tag = tag ^ "@" ^ hash in

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -35,10 +35,12 @@ module type DOCKER = sig
   val peek :
     ?label:string ->
     arch:string ->
+    ?os:string ->
     schedule:Current_cache.Schedule.t ->
     string -> repo_id Current.t
   (** [peek ~schedule ~arch tag] gets the latest version of [tag] without actually pulling it.
       @param arch Select a specific architecture from a multi-arch manifest.
+      @param os Select a specific OS from a multi-platform manifest (default ["linux"]).
       @param schedule Controls how often we check for updates. If the schedule
                       has no [valid_for] limit then we will only ever check once. *)
 


### PR DESCRIPTION
Fixes `docker manifest inspect` peek for Windows images. The previous code hardcoded `os = "linux"` in the manifest filter, so peeking e.g. `ocaml/opam:windows-server-mingw-ltsc2025-ocaml-5.4` failed with `Failed to find arch "amd64" in manifest (Not_found)`. `os` defaults to `"linux"`, so existing callers are unaffected.